### PR TITLE
Fix profile label wrapping

### DIFF
--- a/MedTrackApp/src/screens/Profile/styles.ts
+++ b/MedTrackApp/src/screens/Profile/styles.ts
@@ -225,8 +225,9 @@ export const styles = StyleSheet.create({
   // Update statLabel styles to make Пропущено fit
   statLabel: {
     color: '#888',
-    fontSize: 14,
+    fontSize: 12,
     marginBottom: 5,
+    textAlign: 'center',
   },
   statIcon: {
     marginTop: 5,


### PR DESCRIPTION
## Summary
- resize profile stat label to avoid wrapping

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68488a86121c832f88d2b04a7e5571f3