### PR TITLE
Implement reminder sync hook

### DIFF
--- a/MedTrackApp/App.tsx
+++ b/MedTrackApp/App.tsx
@@ -1,7 +1,14 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import AppNavigator from './src/navigation/AppNavigator';
+import useReminders from './src/hooks/useReminders';
 
 const App = () => {
+  const { syncLocal } = useReminders();
+
+  useEffect(() => {
+    syncLocal();
+  }, [syncLocal]);
+
   return <AppNavigator />;
 };
 

--- a/MedTrackApp/src/hooks/useReminders.ts
+++ b/MedTrackApp/src/hooks/useReminders.ts
@@ -1,0 +1,73 @@
+import { useCallback } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { REMINDERS_ENDPOINT } from '../api';
+import { Reminder } from '../types';
+
+const PENDING_KEY = 'pendingReminders';
+const STORAGE_KEY = 'reminders';
+
+async function mergeWithStorage(key: string, reminders: Reminder[]) {
+  const stored = await AsyncStorage.getItem(key);
+  const existing: Reminder[] = stored ? JSON.parse(stored) : [];
+  await AsyncStorage.setItem(key, JSON.stringify([...existing, ...reminders]));
+}
+
+export default function useReminders() {
+  const scheduleReminders = useCallback(async (reminders: Reminder[]) => {
+    await mergeWithStorage(STORAGE_KEY, reminders);
+    try {
+      const token = await AsyncStorage.getItem('authToken');
+      const tokenType = (await AsyncStorage.getItem('tokenType')) || 'Bearer';
+      if (!token) {
+        throw new Error('No auth token');
+      }
+
+      const response = await fetch(`${REMINDERS_ENDPOINT}/bulk`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `${tokenType} ${token}`,
+        },
+        body: JSON.stringify({ reminders }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status}`);
+      }
+    } catch (error) {
+      console.error('Failed to schedule reminders remotely:', error);
+      await mergeWithStorage(PENDING_KEY, reminders);
+    }
+  }, []);
+
+  const syncLocal = useCallback(async () => {
+    try {
+      const pendingJSON = await AsyncStorage.getItem(PENDING_KEY);
+      const pending: Reminder[] = pendingJSON ? JSON.parse(pendingJSON) : [];
+      if (!pending.length) return;
+
+      const token = await AsyncStorage.getItem('authToken');
+      const tokenType = (await AsyncStorage.getItem('tokenType')) || 'Bearer';
+      if (!token) return;
+
+      const response = await fetch(`${REMINDERS_ENDPOINT}/bulk`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `${tokenType} ${token}`,
+        },
+        body: JSON.stringify({ reminders: pending }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status}`);
+      }
+
+      await AsyncStorage.removeItem(PENDING_KEY);
+    } catch (error) {
+      console.error('Failed to sync local reminders:', error);
+    }
+  }, []);
+
+  return { scheduleReminders, syncLocal };
+}

--- a/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
+++ b/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -17,16 +17,22 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { format } from 'date-fns';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { styles } from './styles';
 import { AddReminderScreenNavigationProp, AddReminderScreenRouteProp, typeIcons } from './types';
 import { Reminder, MedicationType } from '../../types';
+import useReminders from '../../hooks/useReminders';
 
 const ReminderAdd: React.FC = () => {
   const navigation = useNavigation<AddReminderScreenNavigationProp>();
   const route = useRoute<AddReminderScreenRouteProp>();
   const { selectedDate } = route.params || {};
+
+  const { scheduleReminders, syncLocal } = useReminders();
+
+  useEffect(() => {
+    syncLocal();
+  }, [syncLocal]);
 
   console.log('AddReminderScreen opened with date:', selectedDate);
 
@@ -164,38 +170,10 @@ const ReminderAdd: React.FC = () => {
     console.log('Created reminders:', JSON.stringify(newReminders));
 
     try {
-      const storedReminders = await AsyncStorage.getItem('reminders');
-      let allReminders: Reminder[] = [];
-
-      if (storedReminders) {
-        allReminders = JSON.parse(storedReminders);
-        console.log('Existing reminders count:', allReminders.length);
-
-        if (!Array.isArray(allReminders)) {
-          console.error('Invalid reminders format in storage, resetting');
-          allReminders = [];
-        }
-      } else {
-        console.log('No existing reminders in storage');
-      }
-
-      allReminders = [...allReminders, ...newReminders];
-      console.log('New total reminders count:', allReminders.length);
-
-      await AsyncStorage.setItem('reminders', JSON.stringify(allReminders));
-      console.log('Successfully saved all reminders to storage');
-
-      const verification = await AsyncStorage.getItem('reminders');
-      if (verification) {
-        const parsed = JSON.parse(verification);
-        console.log('Verification: stored reminders count:', parsed.length);
-      }
+      await scheduleReminders(newReminders);
     } catch (error) {
-      console.error('Failed to update reminders in storage:', error);
-      Alert.alert(
-        'Storage Error',
-        'Failed to save your reminders. The app will try to add them to your list, but you may need to restart the app.',
-      );
+      console.error('Failed to schedule reminders:', error);
+      Alert.alert('Ошибка', 'Не удалось связаться с сервером. Напоминания сохранены локально.');
     }
 
     navigation.navigate('Main', {


### PR DESCRIPTION
## Summary
- create a `useReminders` hook for scheduling and syncing reminders
- integrate the hook into `ReminderAdd` screen
- sync pending reminders on app start

## Testing
- `npm install`
- `npm test` *(fails: Jest could not transform React Native modules)*

------
https://chatgpt.com/codex/tasks/task_e_68495e932c34832f9323ad6ee3a48f83