### PR TITLE
Fix weekday picker and date formats

### DIFF
--- a/MedTrackApp/src/screens/ReminderAdd/styles.ts
+++ b/MedTrackApp/src/screens/ReminderAdd/styles.ts
@@ -139,9 +139,11 @@ export const styles = StyleSheet.create({
   },
   weekdayOption: {
     backgroundColor: '#1E1E1E',
-    padding: 8,
-    borderRadius: 4,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 6,
     marginRight: 5,
+    marginBottom: 5,
   },
   weekdaySelected: {
     backgroundColor: '#2C2C2C',


### PR DESCRIPTION
## Summary
- ensure weekday picker starts on Monday
- display start/end dates in `dd-MM-yyyy`
- enlarge weekday option buttons

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eef88c634832f9e660e11e6b2af90