### PR TITLE
Fix Medications screen data sync

### DIFF
--- a/MedTrackApp/src/screens/Medications/Medications.tsx
+++ b/MedTrackApp/src/screens/Medications/Medications.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useMedications } from '../../hooks/useMedications';
 import { useCourses, useReminders } from '../../hooks';
 import { MedicationCourse } from '../../types';
@@ -24,7 +24,13 @@ const Medications: React.FC = () => {
   const navigation = useNavigation<MedicationsScreenNavigationProp>();
   const { medications, createMedication, updateMedication, removeMedication } = useMedications();
   const { courses, removeCourse } = useCourses();
-  const { reminders, deleteByCourse } = useReminders();
+  const { reminders, deleteByCourse, fetchReminders } = useReminders();
+
+  useFocusEffect(
+    React.useCallback(() => {
+      fetchReminders();
+    }, []),
+  );
 
   const [form, setForm] = useState<MedicationFormData>({ name: '', dosage: '' });
 


### PR DESCRIPTION
## Summary
- refresh reminders whenever the Medications screen gains focus

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6852f0cdcb54832fb05981ccb09737f8