### PR TITLE
Add single date picker for one-time reminder option

### DIFF
--- a/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
+++ b/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
@@ -444,7 +444,16 @@ const ReminderAdd: React.FC = () => {
           </View>
         )}
 
-        {repeat !== 'once' && (
+        {repeat === 'once' ? (
+          <View style={styles.dateRow}>
+            <View style={styles.dateField}>
+              <Text style={styles.label}>Дата</Text>
+              <TouchableOpacity onPress={openStartPicker} style={styles.addTimeButton}>
+                <Text style={styles.addTimeText}>{formatDisplayDate(startDate)}</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        ) : (
           <View style={styles.dateRow}>
             <View style={[styles.dateField, { marginRight: 10 }]}>
               <Text style={styles.label}>Начало</Text>


### PR DESCRIPTION
## Summary
- show a single date selector when repeat is set to 'once'
- keep existing start/end pickers for other repeat options

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6853d91b4644832fa4ffcc5e9a2e4691