### PR TITLE
Update profile tab layout

### DIFF
--- a/MedTrackApp/src/navigation/AppNavigator.tsx
+++ b/MedTrackApp/src/navigation/AppNavigator.tsx
@@ -49,9 +49,9 @@ const AppNavigator: React.FC = () => {
           options={{ tabBarIcon: ({ color }) => <Icon name="medical-bag" size={30} color={color} /> }}
         />
         <Tab.Screen
-          name="Профиль"
+          name="Статистика"
           component={ProfileStack}
-          options={{ tabBarIcon: ({ color }) => <Icon name="account" size={30} color={color} /> }}
+          options={{ tabBarIcon: ({ color }) => <Icon name="equalizer" size={30} color={color} /> }}
         />
       </Tab.Navigator>
     </NavigationContainer>

--- a/MedTrackApp/src/screens/Profile/Profile.tsx
+++ b/MedTrackApp/src/screens/Profile/Profile.tsx
@@ -224,14 +224,7 @@ const Profile: React.FC = () => {
     <SafeAreaView edges={['top']} style={styles.container}>
       <StatusBar barStyle="light-content" />
       <ScrollView contentContainerStyle={styles.scrollContainer}>
-        <View style={styles.profileHeader}>
-          <View style={styles.avatarContainer}>
-            <Text style={styles.avatarText}>
-              {user.full_name.split(' ').map(name => name[0]).join('').toUpperCase()}
-            </Text>
-          </View>
-          <Text style={styles.nameText}>{user.full_name}</Text>
-        </View>
+
 
 
 

--- a/MedTrackApp/src/screens/Profile/styles.ts
+++ b/MedTrackApp/src/screens/Profile/styles.ts
@@ -9,29 +9,6 @@ export const styles = StyleSheet.create({
     paddingTop: 20,
     paddingHorizontal: 20,
   },
-  profileHeader: {
-    alignItems: 'center',
-    marginBottom: 30,
-  },
-  avatarContainer: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: '#007AFF',
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginBottom: 15,
-  },
-  avatarText: {
-    color: 'white',
-    fontSize: 28,
-    fontWeight: 'bold',
-  },
-  nameText: {
-    color: 'white',
-    fontSize: 24,
-    fontWeight: 'bold',
-  },
   infoSection: {
     backgroundColor: '#1E1E1E',
     borderRadius: 10,


### PR DESCRIPTION
## Summary
- remove avatar and name from Profile screen
- rename "Профиль" tab to "Статистика" and change tab icon

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f890dfe8832fa71318edd0741ef5