### PR TITLE
Fix reminder notification icon

### DIFF
--- a/MedTrackApp/src/utils/notifications.ts
+++ b/MedTrackApp/src/utils/notifications.ts
@@ -26,7 +26,10 @@ export async function reminderNotification({ title, body, date }: ReminderNotifi
       {
         title,
         body,
-        android: { channelId },
+        android: {
+          channelId,
+          smallIcon: 'ic_launcher',
+        },
       },
       trigger,
     );


### PR DESCRIPTION
## Summary
- display app icon in Notifee reminder notifications

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*


------
https://chatgpt.com/codex/tasks/task_e_685552c8fadc832faa5971390266fbd8