### PR TITLE
Move medication form to modal

### DIFF
--- a/MedTrackApp/src/hooks/useCountdown.ts
+++ b/MedTrackApp/src/hooks/useCountdown.ts
@@ -36,7 +36,7 @@ export function useCountdown(target: Date | null, active: boolean, onExpire?: ()
     intervalRef.current = setInterval(update, 1000);
 
     return () => clearInterval(intervalRef.current);
-  }, [target, active]);
+  }, [target, active, onExpire]);
 
   const minutes = Math.floor(remaining / 60)
     .toString()

--- a/MedTrackApp/src/hooks/useReminders.ts
+++ b/MedTrackApp/src/hooks/useReminders.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Reminder, ReminderStatus } from '../types';
 import { reminderNotification } from '../utils/notifications';
@@ -7,7 +7,8 @@ export const useReminders = () => {
   const [reminders, setReminders] = useState<Reminder[]>([]);
   const [loading, setLoading] = useState(false);
 
-  const fetchReminders = async () => {
+  // memoize so useEffect below doesn't trigger on every render
+  const fetchReminders = useCallback(async () => {
     setLoading(true);
     try {
       const stored = await AsyncStorage.getItem('reminders');
@@ -17,7 +18,7 @@ export const useReminders = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   const saveReminders = async (items: Reminder[]) => {
     setReminders(items);
@@ -60,7 +61,7 @@ export const useReminders = () => {
 
   useEffect(() => {
     fetchReminders();
-  }, []);
+  }, [fetchReminders]);
 
   return {
     reminders,

--- a/MedTrackApp/src/screens/Medications/styles.ts
+++ b/MedTrackApp/src/screens/Medications/styles.ts
@@ -4,8 +4,11 @@ export const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingTop: 20,
-    paddingHorizontal: 20,
     backgroundColor: '#121212',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
   },
   header: {
     flexDirection: 'row',
@@ -103,5 +106,40 @@ export const styles = StyleSheet.create({
   },
   courseButton: {
     paddingHorizontal: 8,
+  },
+  fab: {
+    position: 'absolute',
+    bottom: 20,
+    right: 20,
+    backgroundColor: '#007AFF',
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    justifyContent: 'center',
+    alignItems: 'center',
+    elevation: 5,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.3,
+    shadowRadius: 3,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    backgroundColor: '#2C2C2C',
+    width: '90%',
+    borderRadius: 10,
+    padding: 20,
+  },
+  modalTitle: {
+    color: 'white',
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    textAlign: 'center',
   },
 });

--- a/MedTrackApp/src/screens/Medications/types.ts
+++ b/MedTrackApp/src/screens/Medications/types.ts
@@ -1,5 +1,4 @@
 import { NavigationProp } from '@react-navigation/native';
-import { Medication } from '../../types';
 
 export type MedicationsScreenNavigationProp = NavigationProp<any>;
 


### PR DESCRIPTION
## Summary
- open Add Medication modal from new button or FAB
- add UI for Add/Edit medication in a bottom sheet style modal
- reset form and close modal after saving
- expose new FAB and modal styles
- fix lint error in useCountdown hook
- memoize `fetchReminders` to avoid re-render loop
- keep FAB aligned across screens

## Testing
- `npm run lint`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629bf5d104832fbfc49823f353d23a