### PR TITLE
Add delete reminder action in edit screen

### DIFF
--- a/MedTrackApp/src/screens/ReminderEdit/ReminderEdit.tsx
+++ b/MedTrackApp/src/screens/ReminderEdit/ReminderEdit.tsx
@@ -113,6 +113,44 @@ const ReminderEdit: React.FC = () => {
     }
   };
 
+  const deleteReminder = async () => {
+    try {
+      const storedRemindersJson = await AsyncStorage.getItem('reminders');
+      if (storedRemindersJson) {
+        const storedReminders: Reminder[] = JSON.parse(storedRemindersJson);
+        const updatedReminders = storedReminders.filter(r => r.id !== reminder.id);
+        await AsyncStorage.setItem('reminders', JSON.stringify(updatedReminders));
+      }
+
+      if (mainKey) {
+        navigation.goBack();
+        // @ts-ignore
+        navigation.navigate({
+          name: 'Main',
+          key: mainKey,
+          params: {
+            forceRefresh: Date.now(),
+          },
+          merge: true,
+        });
+      } else {
+        navigation.navigate('Main', { forceRefresh: Date.now() });
+      }
+
+      Alert.alert('Удалено', 'Напоминание успешно удалено!');
+    } catch (error) {
+      console.error('Error deleting reminder:', error);
+      Alert.alert('Ошибка', 'Не удалось удалить напоминание');
+    }
+  };
+
+  const confirmDelete = () => {
+    Alert.alert('Удалить напоминание', 'Вы уверены, что хотите удалить это напоминание?', [
+      { text: 'Отмена', style: 'cancel' },
+      { text: 'Удалить', style: 'destructive', onPress: deleteReminder },
+    ]);
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <StatusBar barStyle="light-content" />
@@ -172,6 +210,9 @@ const ReminderEdit: React.FC = () => {
 
       <TouchableOpacity onPress={saveReminder} style={styles.saveButton}>
         <Text style={styles.buttonText}>Сохранить</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={confirmDelete} style={styles.deleteButton}>
+        <Text style={styles.buttonText}>Удалить напоминание</Text>
       </TouchableOpacity>
     </SafeAreaView>
   );

--- a/MedTrackApp/src/screens/ReminderEdit/styles.ts
+++ b/MedTrackApp/src/screens/ReminderEdit/styles.ts
@@ -39,6 +39,13 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     marginTop: 10,
   },
+  deleteButton: {
+    backgroundColor: '#FF3B30',
+    padding: 12,
+    borderRadius: 5,
+    alignItems: 'center',
+    marginTop: 10,
+  },
   buttonText: {
     color: '#fff',
     fontWeight: 'bold',


### PR DESCRIPTION
## Summary
- allow deleting a reminder from the edit screen
- style the new delete button

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68638cd4de7c832f8d0d28e0a8402621