### PR TITLE
Restrict dosage input to decimal numeric keypad

### DIFF
--- a/MedTrackApp/src/screens/Medications/Medications.tsx
+++ b/MedTrackApp/src/screens/Medications/Medications.tsx
@@ -244,7 +244,11 @@ const Medications: React.FC = () => {
                   placeholderTextColor="#666"
                   style={styles.input}
                   value={form.dosage}
-                  onChangeText={dosage => setForm(prev => ({ ...prev, dosage }))}
+                  keyboardType="decimal-pad"
+                  inputMode="decimal"
+                  onChangeText={text =>
+                    setForm(prev => ({ ...prev, dosage: text.replace(/[^0-9,]/g, '') }))
+                  }
                 />
                 <TouchableOpacity style={styles.addButton} onPress={save}>
                   <Text style={styles.addButtonText}>

--- a/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
+++ b/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
@@ -433,7 +433,9 @@ const ReminderAdd: React.FC = () => {
         <TextInput
           style={styles.input}
           value={dosage}
-          onChangeText={setDosage}
+          keyboardType="decimal-pad"
+          inputMode="decimal"
+          onChangeText={(text) => setDosage(text.replace(/[^0-9,]/g, ''))}
           placeholder="Например: 1 таблетка, 5мл"
           placeholderTextColor="#666"
         />

--- a/MedTrackApp/src/screens/ReminderEdit/ReminderEdit.tsx
+++ b/MedTrackApp/src/screens/ReminderEdit/ReminderEdit.tsx
@@ -159,7 +159,13 @@ const ReminderEdit: React.FC = () => {
       <TextInput style={styles.input} value={name} onChangeText={setName} />
 
       <Text style={styles.label}>Дозировка</Text>
-      <TextInput style={styles.input} value={dosage} onChangeText={setDosage} />
+      <TextInput
+        style={styles.input}
+        value={dosage}
+        keyboardType="decimal-pad"
+        inputMode="decimal"
+        onChangeText={(text) => setDosage(text.replace(/[^0-9,]/g, ''))}
+      />
 
       <Text style={styles.label}>Время</Text>
       <TouchableOpacity onPress={openTimePicker} style={styles.timePickerButton}>


### PR DESCRIPTION
## Summary
- add numeric keypad with comma and sanitize input for dosage fields

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6866fd4ce394832fa0dcaf24a2c056d6