### PR TITLE
Restrict dosage input to decimal numeric keypad

### DIFF
--- a/MedTrackApp/src/screens/Medications/Medications.tsx
+++ b/MedTrackApp/src/screens/Medications/Medications.tsx
@@ -237,6 +237,7 @@ const Medications: React.FC = () => {
                   placeholderTextColor="#666"
                   style={styles.input}
                   value={form.name}
+                  maxLength={50}
                   onChangeText={name => setForm(prev => ({ ...prev, name }))}
                 />
                 <TextInput
@@ -244,7 +245,14 @@ const Medications: React.FC = () => {
                   placeholderTextColor="#666"
                   style={styles.input}
                   value={form.dosage}
-                  onChangeText={dosage => setForm(prev => ({ ...prev, dosage }))}
+                  keyboardType="decimal-pad"
+                  inputMode="decimal"
+                  maxLength={7}
+                  onChangeText={text => {
+                    let sanitized = text.replace(/[^0-9,]/g, '').replace(/^,/, '');
+                    sanitized = sanitized.replace(/,(?=.*,)/g, '');
+                    setForm(prev => ({ ...prev, dosage: sanitized }));
+                  }}
                 />
                 <TouchableOpacity style={styles.addButton} onPress={save}>
                   <Text style={styles.addButtonText}>

--- a/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
+++ b/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
@@ -421,6 +421,7 @@ const ReminderAdd: React.FC = () => {
           style={styles.input}
           value={name}
           onChangeText={setName}
+          maxLength={50}
           placeholder="Название лекарства"
           placeholderTextColor="#666"
         />
@@ -433,8 +434,15 @@ const ReminderAdd: React.FC = () => {
         <TextInput
           style={styles.input}
           value={dosage}
-          onChangeText={setDosage}
-          placeholder="Например: 1 таблетка, 5мл"
+          keyboardType="decimal-pad"
+          inputMode="decimal"
+          maxLength={7}
+          onChangeText={(text) => {
+            let sanitized = text.replace(/[^0-9,]/g, '').replace(/^,/, '');
+            sanitized = sanitized.replace(/,(?=.*,)/g, '');
+            setDosage(sanitized);
+          }}
+          placeholder="Например: 1"
           placeholderTextColor="#666"
         />
 

--- a/MedTrackApp/src/screens/ReminderEdit/ReminderEdit.tsx
+++ b/MedTrackApp/src/screens/ReminderEdit/ReminderEdit.tsx
@@ -156,10 +156,26 @@ const ReminderEdit: React.FC = () => {
       <StatusBar barStyle="light-content" />
 
       <Text style={styles.label}>Название</Text>
-      <TextInput style={styles.input} value={name} onChangeText={setName} />
+      <TextInput
+        style={styles.input}
+        value={name}
+        onChangeText={setName}
+        maxLength={50}
+      />
 
       <Text style={styles.label}>Дозировка</Text>
-      <TextInput style={styles.input} value={dosage} onChangeText={setDosage} />
+      <TextInput
+        style={styles.input}
+        value={dosage}
+        keyboardType="decimal-pad"
+        inputMode="decimal"
+        maxLength={7}
+        onChangeText={(text) => {
+          let sanitized = text.replace(/[^0-9,]/g, '').replace(/^,/, '');
+          sanitized = sanitized.replace(/,(?=.*,)/g, '');
+          setDosage(sanitized);
+        }}
+      />
 
       <Text style={styles.label}>Время</Text>
       <TouchableOpacity onPress={openTimePicker} style={styles.timePickerButton}>


### PR DESCRIPTION
## Summary
- add numeric keypad with comma and sanitize input for dosage fields
- limit dosage and medication name fields to reasonable length

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6866fd4ce394832fa0dcaf24a2c056d6