### PR TITLE
Fix medication text overflow

### DIFF
--- a/MedTrackApp/src/screens/Medications/Medications.tsx
+++ b/MedTrackApp/src/screens/Medications/Medications.tsx
@@ -193,8 +193,14 @@ const Medications: React.FC = () => {
         <Text style={styles.sectionTitle}>Список лекарств</Text>
         {medications.map(m => (
           <View key={m.id} style={styles.listItem}>
-            <View>
-              <Text style={styles.listText}>{m.name}</Text>
+            <View style={styles.listInfo}>
+              <Text
+                style={styles.listText}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {m.name}
+              </Text>
               {!!m.dosage && (
                 <Text style={styles.listText}>{m.dosage}</Text>
               )}

--- a/MedTrackApp/src/screens/Medications/styles.ts
+++ b/MedTrackApp/src/screens/Medications/styles.ts
@@ -37,6 +37,10 @@ export const styles = StyleSheet.create({
     borderRadius: 5,
     marginBottom: 8,
   },
+  listInfo: {
+    flex: 1,
+    marginRight: 10,
+  },
   listText: {
     color: 'white',
     fontSize: 16,


### PR DESCRIPTION
## Summary
- prevent medication names from pushing action icons off screen
- add truncation with ellipsis to long names

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6867804879ac832fa770dac6cf9614af