### PR TITLE
Fix dosage text input keyboard

### DIFF
--- a/MedTrackApp/src/screens/Medications/Medications.tsx
+++ b/MedTrackApp/src/screens/Medications/Medications.tsx
@@ -251,14 +251,11 @@ const Medications: React.FC = () => {
                   placeholderTextColor="#666"
                   style={styles.input}
                   value={form.dosage}
-                  keyboardType="decimal-pad"
-                  inputMode="decimal"
-                  maxLength={7}
-                  onChangeText={text => {
-                    let sanitized = text.replace(/[^0-9,]/g, '').replace(/^,/, '');
-                    sanitized = sanitized.replace(/,(?=.*,)/g, '');
-                    setForm(prev => ({ ...prev, dosage: sanitized }));
-                  }}
+                  keyboardType="default"
+                  maxLength={35}
+                  onChangeText={dosage =>
+                    setForm(prev => ({ ...prev, dosage }))
+                  }
                 />
                 <TouchableOpacity style={styles.addButton} onPress={save}>
                   <Text style={styles.addButtonText}>

--- a/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
+++ b/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
@@ -434,14 +434,9 @@ const ReminderAdd: React.FC = () => {
         <TextInput
           style={styles.input}
           value={dosage}
-          keyboardType="decimal-pad"
-          inputMode="decimal"
-          maxLength={7}
-          onChangeText={(text) => {
-            let sanitized = text.replace(/[^0-9,]/g, '').replace(/^,/, '');
-            sanitized = sanitized.replace(/,(?=.*,)/g, '');
-            setDosage(sanitized);
-          }}
+          keyboardType="default"
+          maxLength={35}
+          onChangeText={setDosage}
           placeholder="Например: 1"
           placeholderTextColor="#666"
         />


### PR DESCRIPTION
## Summary
- restore qwerty keyboard for dosage fields
- allow up to 35 characters for dosage input

## Testing
- `npm install`
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6867f65982d0832f8edc521807e89caa