### PR TITLE
Swap reminderAdd date and repeat blocks

### DIFF
--- a/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
+++ b/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
@@ -455,32 +455,6 @@ const ReminderAdd: React.FC = () => {
           ))}
         </View>
 
-        {repeat === 'once' ? (
-          <View style={styles.dateRow}>
-            <View style={styles.dateField}>
-              <Text style={styles.label}>Дата</Text>
-              <TouchableOpacity onPress={openStartPicker} style={styles.addTimeButton}>
-                <Text style={styles.addTimeText}>{formatDisplayDate(startDate)}</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        ) : (
-          <View style={styles.dateRow}>
-            <View style={[styles.dateField, { marginRight: 10 }]}>
-              <Text style={styles.label}>Начало</Text>
-              <TouchableOpacity onPress={openStartPicker} style={styles.addTimeButton}>
-                <Text style={styles.addTimeText}>{formatDisplayDate(startDate)}</Text>
-              </TouchableOpacity>
-            </View>
-            <View style={styles.dateField}>
-              <Text style={styles.label}>Конец</Text>
-              <TouchableOpacity onPress={openEndPicker} style={styles.addTimeButton}>
-                <Text style={styles.addTimeText}>{formatDisplayDate(endDate)}</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        )}
-
         <Text style={styles.label}>Повторять</Text>
         <View style={styles.repeatRow}>
           {[
@@ -516,6 +490,32 @@ const ReminderAdd: React.FC = () => {
                 </TouchableOpacity>
               );
             })}
+          </View>
+        )}
+
+        {repeat === 'once' ? (
+          <View style={styles.dateRow}>
+            <View style={styles.dateField}>
+              <Text style={styles.label}>Дата</Text>
+              <TouchableOpacity onPress={openStartPicker} style={styles.addTimeButton}>
+                <Text style={styles.addTimeText}>{formatDisplayDate(startDate)}</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        ) : (
+          <View style={styles.dateRow}>
+            <View style={[styles.dateField, { marginRight: 10 }]}>
+              <Text style={styles.label}>Начало</Text>
+              <TouchableOpacity onPress={openStartPicker} style={styles.addTimeButton}>
+                <Text style={styles.addTimeText}>{formatDisplayDate(startDate)}</Text>
+              </TouchableOpacity>
+            </View>
+            <View style={styles.dateField}>
+              <Text style={styles.label}>Конец</Text>
+              <TouchableOpacity onPress={openEndPicker} style={styles.addTimeButton}>
+                <Text style={styles.addTimeText}>{formatDisplayDate(endDate)}</Text>
+              </TouchableOpacity>
+            </View>
           </View>
         )}
 


### PR DESCRIPTION
## Summary
- swap "date" and "repeat" UI blocks in ReminderAdd screen

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook dependencies, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686a71b279bc832f8a2182234a34d89a