### PR TITLE
Fix ReminderAdd order

### DIFF
--- a/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
+++ b/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
@@ -455,32 +455,6 @@ const ReminderAdd: React.FC = () => {
           ))}
         </View>
 
-        {repeat === 'once' ? (
-          <View style={styles.dateRow}>
-            <View style={styles.dateField}>
-              <Text style={styles.label}>Дата</Text>
-              <TouchableOpacity onPress={openStartPicker} style={styles.addTimeButton}>
-                <Text style={styles.addTimeText}>{formatDisplayDate(startDate)}</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        ) : (
-          <View style={styles.dateRow}>
-            <View style={[styles.dateField, { marginRight: 10 }]}>
-              <Text style={styles.label}>Начало</Text>
-              <TouchableOpacity onPress={openStartPicker} style={styles.addTimeButton}>
-                <Text style={styles.addTimeText}>{formatDisplayDate(startDate)}</Text>
-              </TouchableOpacity>
-            </View>
-            <View style={styles.dateField}>
-              <Text style={styles.label}>Конец</Text>
-              <TouchableOpacity onPress={openEndPicker} style={styles.addTimeButton}>
-                <Text style={styles.addTimeText}>{formatDisplayDate(endDate)}</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        )}
-
         <Text style={styles.label}>Повторять</Text>
         <View style={styles.repeatRow}>
           {[
@@ -516,6 +490,32 @@ const ReminderAdd: React.FC = () => {
                 </TouchableOpacity>
               );
             })}
+          </View>
+        )}
+
+        {repeat === 'once' ? (
+          <View style={styles.dateRow}>
+            <View style={styles.dateField}>
+              <Text style={styles.label}>Дата</Text>
+              <TouchableOpacity onPress={openStartPicker} style={styles.addTimeButton}>
+                <Text style={styles.addTimeText}>{formatDisplayDate(startDate)}</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        ) : (
+          <View style={styles.dateRow}>
+            <View style={[styles.dateField, { marginRight: 10 }]}>
+              <Text style={styles.label}>Начало</Text>
+              <TouchableOpacity onPress={openStartPicker} style={styles.addTimeButton}>
+                <Text style={styles.addTimeText}>{formatDisplayDate(startDate)}</Text>
+              </TouchableOpacity>
+            </View>
+            <View style={styles.dateField}>
+              <Text style={styles.label}>Конец</Text>
+              <TouchableOpacity onPress={openEndPicker} style={styles.addTimeButton}>
+                <Text style={styles.addTimeText}>{formatDisplayDate(endDate)}</Text>
+              </TouchableOpacity>
+            </View>
           </View>
         )}
 


### PR DESCRIPTION
## Summary
- reorder form fields in ReminderAdd so the order is name, dosage, type, repeat, date, and time

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8e32f3bc832f94d1bc69d417e9e9