### PR TITLE
Fix returning from reminder forms to tabbed Main

### DIFF
--- a/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
+++ b/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
@@ -373,24 +373,18 @@ const ReminderAdd: React.FC = () => {
       }
     }
 
-    if (mainKey) {
-      navigation.goBack();
-      // @ts-ignore
-      navigation.navigate({
-        name: 'Main',
-        key: mainKey,
-        params: {
-          newReminders,
-          forceRefresh: Date.now(),
-        },
-        merge: true,
-      });
-    } else {
-      navigation.navigate('Main', {
+    const key = mainKey || navigation.getState().routes[0]?.key;
+    navigation.goBack();
+    // @ts-ignore
+    navigation.navigate({
+      name: 'Main',
+      key,
+      params: {
         newReminders,
         forceRefresh: Date.now(),
-      });
-    }
+      },
+      merge: true,
+    });
 
     const reminderText = newReminders.length === 1 ? 'напоминание' : 'напоминания';
     Alert.alert('Добавлено', `${newReminders.length} ${reminderText} успешно создано!`);

--- a/MedTrackApp/src/screens/ReminderEdit/ReminderEdit.tsx
+++ b/MedTrackApp/src/screens/ReminderEdit/ReminderEdit.tsx
@@ -89,24 +89,18 @@ const ReminderEdit: React.FC = () => {
       }
 
       // Navigate back to Main screen with updated reminder
-      if (mainKey) {
-        navigation.goBack();
-        // @ts-ignore
-        navigation.navigate({
-          name: 'Main',
-          key: mainKey,
-          params: {
-            updatedReminder,
-            forceRefresh: Date.now(),
-          },
-          merge: true,
-        });
-      } else {
-        navigation.navigate('Main', {
+      const key = mainKey || navigation.getState().routes[0]?.key;
+      navigation.goBack();
+      // @ts-ignore
+      navigation.navigate({
+        name: 'Main',
+        key,
+        params: {
           updatedReminder,
           forceRefresh: Date.now(),
-        });
-      }
+        },
+        merge: true,
+      });
 
       Alert.alert('Сохранено', 'Напоминание успешно обновлено!');
     } catch (error) {
@@ -132,20 +126,17 @@ const ReminderEdit: React.FC = () => {
         }
       }
 
-      if (mainKey) {
-        navigation.goBack();
-        // @ts-ignore
-        navigation.navigate({
-          name: 'Main',
-          key: mainKey,
-          params: {
-            forceRefresh: Date.now(),
-          },
-          merge: true,
-        });
-      } else {
-        navigation.navigate('Main', { forceRefresh: Date.now() });
-      }
+      const key = mainKey || navigation.getState().routes[0]?.key;
+      navigation.goBack();
+      // @ts-ignore
+      navigation.navigate({
+        name: 'Main',
+        key,
+        params: {
+          forceRefresh: Date.now(),
+        },
+        merge: true,
+      });
 
       Alert.alert('Удалено', 'Напоминание успешно удалено!');
     } catch (error) {


### PR DESCRIPTION
## Summary
- avoid creating new Main instances after adding or editing reminders
- always navigate back to the original Main screen with updated params

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_686a95f714e4832f993b1b8abfe43107