### PR TITLE
Implement editable profile screen

### DIFF
--- a/MedTrackApp/jest.config.js
+++ b/MedTrackApp/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
     '^@notifee/react-native$': '<rootDir>/__mocks__/notifeeReactNative.js',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@react-navigation|react-native-vector-icons|@react-native-community/datetimepicker|react-native-chart-kit)/)',
+    'node_modules/(?!(react-native|@react-native|@react-navigation|react-native-vector-icons|@react-native-community/datetimepicker|@react-native-picker/picker|react-native-chart-kit)/)',
   ],
   setupFiles: [
     './node_modules/react-native-gesture-handler/jestSetup.js',

--- a/MedTrackApp/jest.config.js
+++ b/MedTrackApp/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
     '^@notifee/react-native$': '<rootDir>/__mocks__/notifeeReactNative.js',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@react-navigation|react-native-vector-icons|@react-native-community/datetimepicker|@react-native-picker/picker|react-native-chart-kit)/)',
+    'node_modules/(?!(react-native|@react-native|@react-navigation|react-native-vector-icons|@react-native-community/datetimepicker|@react-native-picker/picker|react-native-date-picker|react-native-chart-kit)/)',
   ],
   setupFiles: [
     './node_modules/react-native-gesture-handler/jestSetup.js',

--- a/MedTrackApp/package-lock.json
+++ b/MedTrackApp/package-lock.json
@@ -21,6 +21,7 @@
         "react-native-calendars": "^1.1310.0",
         "react-native-change-icon": "^5.0.0",
         "react-native-chart-kit": "^6.12.0",
+        "react-native-date-picker": "^5.0.13",
         "react-native-gesture-handler": "^2.24.0",
         "react-native-reanimated": "^3.17.1",
         "react-native-safe-area-context": "^5.3.0",
@@ -11261,6 +11262,16 @@
         "react": "> 16.7.0",
         "react-native": ">= 0.50.0",
         "react-native-svg": "> 6.4.1"
+      }
+    },
+    "node_modules/react-native-date-picker": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/react-native-date-picker/-/react-native-date-picker-5.0.13.tgz",
+      "integrity": "sha512-qCLUODZVsJetO5zuoXjw1D39K527XWqBG8sOfhWdHyPzf13h8RXR1/RSKd1N0fdRDi5GdyizYmB0lPAK12/hbw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 17.0.1",
+        "react-native": ">= 0.64.3"
       }
     },
     "node_modules/react-native-gesture-handler": {

--- a/MedTrackApp/package.json
+++ b/MedTrackApp/package.json
@@ -23,6 +23,7 @@
     "react-native-calendars": "^1.1310.0",
     "react-native-change-icon": "^5.0.0",
     "react-native-chart-kit": "^6.12.0",
+    "react-native-date-picker": "^5.0.13",
     "react-native-gesture-handler": "^2.24.0",
     "react-native-reanimated": "^3.17.1",
     "react-native-safe-area-context": "^5.3.0",

--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -13,7 +13,6 @@ import {
   Alert,
 } from 'react-native';
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
-import { Picker } from '@react-native-picker/picker';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -30,13 +29,69 @@ interface ProfileData {
   middleName: string;
   phone: string;
   email: string;
-  gender: 'Мужской' | 'Женский' | 'Не указан';
+  gender: 'Мужской' | 'Женский';
   birthDate: string;
   vk: string;
   instagram: string;
   odnoklassniki: string;
   telegram: string;
 }
+
+interface GenderSelectorProps {
+  value: 'Мужской' | 'Женский';
+  onChange: (gender: 'Мужской' | 'Женский') => void;
+}
+
+const GenderSelector: React.FC<GenderSelectorProps> = ({ value, onChange }) => {
+  return (
+    <View style={styles.genderContainer}>
+      <TouchableOpacity
+        style={[
+          styles.genderButton,
+          value === 'Мужской' && styles.genderButtonActive,
+        ]}
+        onPress={() => onChange('Мужской')}
+        accessibilityRole="button"
+      >
+        <Icon
+          name="gender-male"
+          size={28}
+          color={value === 'Мужской' ? 'white' : '#888'}
+        />
+        <Text
+          style={[
+            styles.genderLabel,
+            value === 'Мужской' && styles.genderLabelActive,
+          ]}
+        >
+          Мужской
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={[
+          styles.genderButton,
+          value === 'Женский' && styles.genderButtonActive,
+        ]}
+        onPress={() => onChange('Женский')}
+        accessibilityRole="button"
+      >
+        <Icon
+          name="gender-female"
+          size={28}
+          color={value === 'Женский' ? 'white' : '#888'}
+        />
+        <Text
+          style={[
+            styles.genderLabel,
+            value === 'Женский' && styles.genderLabelActive,
+          ]}
+        >
+          Женский
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
 
 const STORAGE_KEY = 'userProfile';
 
@@ -48,7 +103,7 @@ const AccountScreen: React.FC = () => {
     middleName: '',
     phone: '',
     email: '',
-    gender: 'Не указан',
+    gender: 'Мужской',
     birthDate: '',
     vk: '',
     instagram: '',
@@ -62,7 +117,9 @@ const AccountScreen: React.FC = () => {
       try {
         const stored = await AsyncStorage.getItem(STORAGE_KEY);
         if (stored) {
-          setProfile(prev => ({ ...prev, ...JSON.parse(stored) }));
+          const parsed = JSON.parse(stored) as Partial<ProfileData>;
+          const gender = parsed.gender === 'Женский' ? 'Женский' : 'Мужской';
+          setProfile(prev => ({ ...prev, ...parsed, gender }));
         }
       } catch {
         // ignore
@@ -147,21 +204,12 @@ const AccountScreen: React.FC = () => {
                 }
               />
               <Text style={styles.label}>Пол</Text>
-              <View style={styles.input}>
-                <Picker
-                  selectedValue={profile.gender}
-                  onValueChange={gender =>
-                    setProfile(prev => ({ ...prev, gender: gender as ProfileData["gender"] }))
-                  }
-                  dropdownIconColor="white"
-                  style={{ color: 'white' }}
-                  itemStyle={{ color: 'white' }}
-                >
-                  <Picker.Item label="Мужской" value="Мужской" color="white" />
-                  <Picker.Item label="Женский" value="Женский" color="white" />
-                  <Picker.Item label="Не указан" value="Не указан" color="white" />
-                </Picker>
-              </View>
+              <GenderSelector
+                value={profile.gender}
+                onChange={gender =>
+                  setProfile(prev => ({ ...prev, gender }))
+                }
+              />
               <Text style={styles.label}>Дата рождения</Text>
               <TouchableOpacity
                 style={styles.dateButton}

--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -1,15 +1,272 @@
-import React from 'react';
-import { Text, View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  StatusBar,
+  KeyboardAvoidingView,
+  Platform,
+  TouchableWithoutFeedback,
+  Keyboard,
+  Alert,
+} from 'react-native';
+import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import { Picker } from '@react-native-picker/picker';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { format } from 'date-fns';
+import { RootStackParamList } from '../../navigation';
 
 import { styles } from './styles';
 
-const AccountScreen: React.FC = () => (
-  <SafeAreaView edges={['top']} style={styles.container}>
-    <View style={styles.content}>
-      <Text style={styles.title}>Account Screen</Text>
-    </View>
-  </SafeAreaView>
-);
+interface ProfileData {
+  lastName: string;
+  firstName: string;
+  middleName: string;
+  phone: string;
+  email: string;
+  gender: 'Мужской' | 'Женский' | 'Не указан';
+  birthDate: string;
+  vk: string;
+  instagram: string;
+  odnoklassniki: string;
+  telegram: string;
+}
+
+const STORAGE_KEY = 'userProfile';
+
+const AccountScreen: React.FC = () => {
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList, 'Account'>>();
+  const [profile, setProfile] = useState<ProfileData>({
+    lastName: '',
+    firstName: '',
+    middleName: '',
+    phone: '',
+    email: '',
+    gender: 'Не указан',
+    birthDate: '',
+    vk: '',
+    instagram: '',
+    odnoklassniki: '',
+    telegram: '',
+  });
+  const [showDatePicker, setShowDatePicker] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          setProfile(prev => ({ ...prev, ...JSON.parse(stored) }));
+        }
+      } catch {
+        // ignore
+      }
+    };
+    load();
+  }, []);
+
+  const onChangeDate = (_: DateTimePickerEvent, date?: Date) => {
+    setShowDatePicker(Platform.OS === 'ios');
+    if (date) {
+      setProfile(prev => ({ ...prev, birthDate: date.toISOString() }));
+    }
+  };
+
+  const save = async () => {
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(profile));
+      Alert.alert('Изменения сохранены');
+    } catch {
+      Alert.alert('Ошибка', 'Не удалось сохранить данные');
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    if (!dateStr) return 'Выберите дату';
+    const d = new Date(dateStr);
+    return format(d, 'dd.MM.yyyy');
+  };
+
+  return (
+    <SafeAreaView edges={["top"]} style={styles.container}>
+      <StatusBar barStyle="light-content" />
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+          <ScrollView contentContainerStyle={styles.contentContainer}>
+            <View style={styles.header}>
+              <Icon
+                name="arrow-left"
+                size={24}
+                color="white"
+                onPress={navigation.goBack}
+              />
+              <Text style={styles.headerTitle}>Профиль</Text>
+              <View style={{ width: 24 }} />
+            </View>
+            <View style={styles.avatarWrapper}>
+              <View style={styles.avatar}>
+                <Icon name="account" size={40} color="#888" />
+              </View>
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>Основные данные</Text>
+              <Text style={styles.label}>Фамилия</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="Фамилия"
+                placeholderTextColor="#666"
+                value={profile.lastName}
+                onChangeText={lastName => setProfile(prev => ({ ...prev, lastName }))}
+              />
+              <Text style={styles.label}>Имя</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="Имя"
+                placeholderTextColor="#666"
+                value={profile.firstName}
+                onChangeText={firstName => setProfile(prev => ({ ...prev, firstName }))}
+              />
+              <Text style={styles.label}>Отчество</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="Отчество"
+                placeholderTextColor="#666"
+                value={profile.middleName}
+                onChangeText={middleName =>
+                  setProfile(prev => ({ ...prev, middleName }))
+                }
+              />
+              <Text style={styles.label}>Пол</Text>
+              <View style={styles.input}>
+                <Picker
+                  selectedValue={profile.gender}
+                  onValueChange={gender =>
+                    setProfile(prev => ({ ...prev, gender: gender as ProfileData["gender"] }))
+                  }
+                  dropdownIconColor="white"
+                  style={{ color: 'white' }}
+                >
+                  <Picker.Item label="Мужской" value="Мужской" />
+                  <Picker.Item label="Женский" value="Женский" />
+                  <Picker.Item label="Не указан" value="Не указан" />
+                </Picker>
+              </View>
+              <Text style={styles.label}>Дата рождения</Text>
+              <TouchableOpacity
+                style={styles.dateButton}
+                onPress={() => setShowDatePicker(true)}
+              >
+                <Text style={{ color: profile.birthDate ? 'white' : '#666' }}>
+                  {formatDate(profile.birthDate)}
+                </Text>
+                <Icon name="calendar" size={20} color="#888" />
+              </TouchableOpacity>
+              {showDatePicker && (
+                <DateTimePicker
+                  value={profile.birthDate ? new Date(profile.birthDate) : new Date()}
+                  mode="date"
+                  display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                  maximumDate={new Date()}
+                  onChange={onChangeDate}
+                />
+              )}
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>Контакты</Text>
+              <Text style={styles.label}>Телефон</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="Телефон"
+                placeholderTextColor="#666"
+                keyboardType="phone-pad"
+                value={profile.phone}
+                onChangeText={phone => setProfile(prev => ({ ...prev, phone }))}
+              />
+              <Text style={styles.label}>Email</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="Email"
+                placeholderTextColor="#666"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                value={profile.email}
+                onChangeText={email => setProfile(prev => ({ ...prev, email }))}
+              />
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>Соцсети</Text>
+              <Text style={styles.label}>ВКонтакте</Text>
+              <View style={styles.rowInput}>
+                <Icon name="vk" size={20} style={styles.icon} />
+                <TextInput
+                  style={[styles.input, { flex: 1 }]}
+                  placeholder="ВКонтакте"
+                  placeholderTextColor="#666"
+                  value={profile.vk}
+                  onChangeText={vk => setProfile(prev => ({ ...prev, vk }))}
+                />
+              </View>
+              <Text style={styles.label}>Instagram</Text>
+              <View style={styles.rowInput}>
+                <Icon name="instagram" size={20} style={styles.icon} />
+                <TextInput
+                  style={[styles.input, { flex: 1 }]}
+                  placeholder="Instagram"
+                  placeholderTextColor="#666"
+                  value={profile.instagram}
+                  onChangeText={instagram =>
+                    setProfile(prev => ({ ...prev, instagram }))
+                  }
+                />
+              </View>
+              <Text style={styles.label}>Одноклассники</Text>
+              <View style={styles.rowInput}>
+                <Icon name="alpha-o-circle" size={20} style={styles.icon} />
+                <TextInput
+                  style={[styles.input, { flex: 1 }]}
+                  placeholder="Одноклассники"
+                  placeholderTextColor="#666"
+                  value={profile.odnoklassniki}
+                  onChangeText={odnoklassniki =>
+                    setProfile(prev => ({ ...prev, odnoklassniki }))
+                  }
+                />
+              </View>
+              <Text style={styles.label}>Telegram</Text>
+              <View style={styles.rowInput}>
+                <Icon name="telegram" size={20} style={styles.icon} />
+                <TextInput
+                  style={[styles.input, { flex: 1 }]}
+                  placeholder="Telegram"
+                  placeholderTextColor="#666"
+                  value={profile.telegram}
+                  onChangeText={telegram =>
+                    setProfile(prev => ({ ...prev, telegram }))
+                  }
+                />
+              </View>
+            </View>
+
+            <TouchableOpacity style={styles.saveButton} onPress={save}>
+              <Text style={styles.saveButtonText}>Сохранить</Text>
+            </TouchableOpacity>
+          </ScrollView>
+        </TouchableWithoutFeedback>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
 
 export default AccountScreen;

--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -155,10 +155,11 @@ const AccountScreen: React.FC = () => {
                   }
                   dropdownIconColor="white"
                   style={{ color: 'white' }}
+                  itemStyle={{ color: 'white' }}
                 >
-                  <Picker.Item label="Мужской" value="Мужской" />
-                  <Picker.Item label="Женский" value="Женский" />
-                  <Picker.Item label="Не указан" value="Не указан" />
+                  <Picker.Item label="Мужской" value="Мужской" color="white" />
+                  <Picker.Item label="Женский" value="Женский" color="white" />
+                  <Picker.Item label="Не указан" value="Не указан" color="white" />
                 </Picker>
               </View>
               <Text style={styles.label}>Дата рождения</Text>

--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -11,8 +11,9 @@ import {
   TouchableWithoutFeedback,
   Keyboard,
   Alert,
+  Modal,
 } from 'react-native';
-import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import DatePicker from 'react-native-date-picker';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -111,6 +112,7 @@ const AccountScreen: React.FC = () => {
     telegram: '',
   });
   const [showDatePicker, setShowDatePicker] = useState(false);
+  const [tempDate, setTempDate] = useState(new Date());
 
   useEffect(() => {
     const load = async () => {
@@ -128,11 +130,14 @@ const AccountScreen: React.FC = () => {
     load();
   }, []);
 
-  const onChangeDate = (_: DateTimePickerEvent, date?: Date) => {
-    setShowDatePicker(Platform.OS === 'ios');
-    if (date) {
-      setProfile(prev => ({ ...prev, birthDate: date.toISOString() }));
-    }
+  const openDatePicker = () => {
+    setTempDate(profile.birthDate ? new Date(profile.birthDate) : new Date());
+    setShowDatePicker(true);
+  };
+
+  const confirmDate = () => {
+    setProfile(prev => ({ ...prev, birthDate: tempDate.toISOString() }));
+    setShowDatePicker(false);
   };
 
   const save = async () => {
@@ -213,22 +218,13 @@ const AccountScreen: React.FC = () => {
               <Text style={styles.label}>Дата рождения</Text>
               <TouchableOpacity
                 style={styles.dateButton}
-                onPress={() => setShowDatePicker(true)}
+                onPress={openDatePicker}
               >
                 <Text style={{ color: profile.birthDate ? 'white' : '#666' }}>
                   {formatDate(profile.birthDate)}
                 </Text>
                 <Icon name="calendar" size={20} color="#888" />
               </TouchableOpacity>
-              {showDatePicker && (
-                <DateTimePicker
-                  value={profile.birthDate ? new Date(profile.birthDate) : new Date()}
-                  mode="date"
-                  display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-                  maximumDate={new Date()}
-                  onChange={onChangeDate}
-                />
-              )}
             </View>
 
             <View style={styles.section}>
@@ -311,6 +307,40 @@ const AccountScreen: React.FC = () => {
             <TouchableOpacity style={styles.saveButton} onPress={save}>
               <Text style={styles.saveButtonText}>Сохранить</Text>
             </TouchableOpacity>
+
+            <Modal
+              visible={showDatePicker}
+              transparent
+              animationType="slide"
+              onRequestClose={() => setShowDatePicker(false)}
+            >
+              <TouchableWithoutFeedback onPress={() => setShowDatePicker(false)}>
+                <View style={styles.modalOverlay}>
+                  <TouchableWithoutFeedback>
+                    <View style={styles.modalContent}>
+                      <View style={styles.modalHeader}>
+                        <TouchableOpacity onPress={() => setShowDatePicker(false)}>
+                          <Icon name="close" size={24} color="white" />
+                        </TouchableOpacity>
+                        <TouchableOpacity onPress={confirmDate}>
+                          <Text style={styles.doneText}>Готово</Text>
+                        </TouchableOpacity>
+                      </View>
+                      <DatePicker
+                        date={tempDate}
+                        mode="date"
+                        maximumDate={new Date()}
+                        onDateChange={setTempDate}
+                        locale="ru"
+                        textColor="white"
+                        fadeToColor="none"
+                        style={styles.datePicker}
+                      />
+                    </View>
+                  </TouchableWithoutFeedback>
+                </View>
+              </TouchableWithoutFeedback>
+            </Modal>
           </ScrollView>
         </TouchableWithoutFeedback>
       </KeyboardAvoidingView>

--- a/MedTrackApp/src/screens/AccountScreen/styles.ts
+++ b/MedTrackApp/src/screens/AccountScreen/styles.ts
@@ -5,14 +5,85 @@ export const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#121212',
   },
-  content: {
+  contentContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 20,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 10,
+    paddingBottom: 15,
+  },
+  headerTitle: {
     flex: 1,
+    textAlign: 'center',
+    fontSize: 24,
+    color: 'white',
+    fontWeight: 'bold',
+  },
+  avatarWrapper: {
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  avatar: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: '#2C2C2C',
     justifyContent: 'center',
     alignItems: 'center',
   },
-  title: {
+  section: {
+    marginBottom: 20,
+  },
+  sectionTitle: {
     color: 'white',
-    fontSize: 20,
+    fontSize: 18,
     fontWeight: 'bold',
+    marginBottom: 10,
+  },
+  label: {
+    color: '#aaa',
+    fontSize: 14,
+    marginBottom: 4,
+    marginTop: 10,
+  },
+  input: {
+    backgroundColor: '#1E1E1E',
+    color: 'white',
+    padding: 10,
+    borderRadius: 8,
+    marginBottom: 10,
+  },
+  rowInput: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  icon: {
+    marginRight: 10,
+    color: '#888',
+  },
+  dateButton: {
+    backgroundColor: '#1E1E1E',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 10,
+    borderRadius: 8,
+    marginBottom: 10,
+  },
+  saveButton: {
+    backgroundColor: '#007AFF',
+    padding: 15,
+    borderRadius: 10,
+    alignItems: 'center',
+    marginTop: 10,
+    marginBottom: 30,
+  },
+  saveButtonText: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: 16,
   },
 });

--- a/MedTrackApp/src/screens/AccountScreen/styles.ts
+++ b/MedTrackApp/src/screens/AccountScreen/styles.ts
@@ -64,6 +64,37 @@ export const styles = StyleSheet.create({
     marginRight: 10,
     color: '#888',
   },
+  genderContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 10,
+    marginBottom: 10,
+  },
+  genderButton: {
+    flex: 1,
+    backgroundColor: '#1E1E1E',
+    borderRadius: 12,
+    paddingVertical: 10,
+    alignItems: 'center',
+    marginHorizontal: 5,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 2,
+    elevation: 3,
+  },
+  genderButtonActive: {
+    backgroundColor: '#007AFF',
+  },
+  genderLabel: {
+    marginTop: 4,
+    color: '#888',
+    fontSize: 14,
+  },
+  genderLabelActive: {
+    color: 'white',
+    fontWeight: 'bold',
+  },
   dateButton: {
     backgroundColor: '#1E1E1E',
     flexDirection: 'row',

--- a/MedTrackApp/src/screens/AccountScreen/styles.ts
+++ b/MedTrackApp/src/screens/AccountScreen/styles.ts
@@ -117,4 +117,29 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     fontSize: 16,
   },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    backgroundColor: '#121212',
+    padding: 20,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  doneText: {
+    color: '#007AFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  datePicker: {
+    alignSelf: 'center',
+  },
 });


### PR DESCRIPTION
## Summary
- build a profile editor in `AccountScreen`
- style profile screen for dark mode
- include picker library in Jest config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a299618a8832fa8e3af6c7ad637b1