### PR TITLE
feat: add speed dial for medication access

### DIFF
--- a/MedTrackApp/src/navigation/AppNavigator.tsx
+++ b/MedTrackApp/src/navigation/AppNavigator.tsx
@@ -27,18 +27,13 @@ const MedCalendarStack = () => (
     <Stack.Screen name="MedCalendar" component={MedCalendarScreen} />
     <Stack.Screen name="ReminderEdit" component={ReminderEdit} />
     <Stack.Screen name="ReminderAdd" component={ReminderAdd} />
+    <Stack.Screen name="Medications" component={Medications} />
   </Stack.Navigator>
 );
 
 const ProfileStack = () => (
   <Stack.Navigator screenOptions={{ headerShown: false }}>
     <Stack.Screen name="Profile" component={Profile} />
-    <Stack.Screen name="Medications" component={Medications} />
-  </Stack.Navigator>
-);
-
-const MedicationsStack = () => (
-  <Stack.Navigator screenOptions={{ headerShown: false }}>
     <Stack.Screen name="Medications" component={Medications} />
   </Stack.Navigator>
 );
@@ -56,11 +51,6 @@ const AppNavigator: React.FC = () => {
           name="Лекарства"
           component={MedCalendarStack}
           options={{ tabBarIcon: ({ color }) => <Icon name="pill" size={30} color={color} /> }}
-        />
-        <Tab.Screen
-          name="Препараты"
-          component={MedicationsStack}
-          options={{ tabBarIcon: ({ color }) => <Icon name="medical-bag" size={30} color={color} /> }}
         />
         <Tab.Screen
           name="Статистика"

--- a/MedTrackApp/src/screens/MedCalendarScreen/styles.ts
+++ b/MedTrackApp/src/screens/MedCalendarScreen/styles.ts
@@ -152,10 +152,13 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginTop: 5,
   },
-  fab: {
+  fabContainer: {
     position: 'absolute',
     bottom: 20,
     right: 20,
+    alignItems: 'center',
+  },
+  fab: {
     backgroundColor: '#007AFF',
     width: 60,
     height: 60,
@@ -167,6 +170,33 @@ export const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.3,
     shadowRadius: 3,
+  },
+  fabBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+  },
+  fabOption: {
+    position: 'absolute',
+    right: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  fabOptionButton: {
+    backgroundColor: '#007AFF',
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginLeft: 10,
+  },
+  fabLabel: {
+    color: 'white',
+    fontSize: 16,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 5,
   },
   emptyListContainer: {
     flex: 1,


### PR DESCRIPTION
## Summary
- drop Medications tab from bottom navigator
- add Medications screen to calendar stack and access via a speed dial floating action button

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook useEffect has a missing dependency: 'isWeekdayInRange', and others)*

------
https://chatgpt.com/codex/tasks/task_e_689055c8d83c832fa3061de7e0b8589a