### PR TITLE
feat: add medications speed dial

### DIFF
--- a/MedTrackApp/src/navigation/AppNavigator.tsx
+++ b/MedTrackApp/src/navigation/AppNavigator.tsx
@@ -27,18 +27,13 @@ const MedCalendarStack = () => (
     <Stack.Screen name="MedCalendar" component={MedCalendarScreen} />
     <Stack.Screen name="ReminderEdit" component={ReminderEdit} />
     <Stack.Screen name="ReminderAdd" component={ReminderAdd} />
+    <Stack.Screen name="Medications" component={Medications} />
   </Stack.Navigator>
 );
 
 const ProfileStack = () => (
   <Stack.Navigator screenOptions={{ headerShown: false }}>
     <Stack.Screen name="Profile" component={Profile} />
-    <Stack.Screen name="Medications" component={Medications} />
-  </Stack.Navigator>
-);
-
-const MedicationsStack = () => (
-  <Stack.Navigator screenOptions={{ headerShown: false }}>
     <Stack.Screen name="Medications" component={Medications} />
   </Stack.Navigator>
 );
@@ -56,11 +51,6 @@ const AppNavigator: React.FC = () => {
           name="Лекарства"
           component={MedCalendarStack}
           options={{ tabBarIcon: ({ color }) => <Icon name="pill" size={30} color={color} /> }}
-        />
-        <Tab.Screen
-          name="Препараты"
-          component={MedicationsStack}
-          options={{ tabBarIcon: ({ color }) => <Icon name="medical-bag" size={30} color={color} /> }}
         />
         <Tab.Screen
           name="Статистика"

--- a/MedTrackApp/src/screens/MedCalendarScreen/styles.ts
+++ b/MedTrackApp/src/screens/MedCalendarScreen/styles.ts
@@ -154,7 +154,6 @@ export const styles = StyleSheet.create({
   },
   fab: {
     position: 'absolute',
-    bottom: 20,
     right: 20,
     backgroundColor: '#007AFF',
     width: 60,
@@ -167,6 +166,28 @@ export const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.3,
     shadowRadius: 3,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  speedDialActions: {
+    position: 'absolute',
+    right: 20,
+    alignItems: 'flex-end',
+  },
+  speedDialAction: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#007AFF',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 30,
+    marginBottom: 12,
+  },
+  speedDialLabel: {
+    color: 'white',
+    fontWeight: 'bold',
+    marginLeft: 8,
   },
   emptyListContainer: {
     flex: 1,


### PR DESCRIPTION
## Summary
- remove medications tab and make screen part of calendar stack
- add speed dial FAB with links to reminder and medications pages
- space FAB actions above tab bar using safe-area offsets

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook useEffect has a missing dependency and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689066eb6444832f955b6bae17fb5c41