### PR TITLE
fix: avoid duplicate calendar screen

### DIFF
--- a/MedTrackApp/src/screens/Medications/Medications.tsx
+++ b/MedTrackApp/src/screens/Medications/Medications.tsx
@@ -101,25 +101,18 @@ const Medications: React.FC = () => {
   });
 
   const navigateToCalendar = () => {
-    let nav: any = navigation;
-    while (nav?.getState && !nav.getState().routes.find((r: any) => r.name === 'MedCalendar')) {
-      const parent = nav.getParent?.();
-      if (!parent) break;
-      nav = parent;
-    }
+    const parent = navigation.getParent?.();
+    const state = parent?.getState?.();
 
-    const state = nav?.getState?.();
-    const calendarRoute = state?.routes.find((r: any) => r.name === 'MedCalendar');
-
-    if (calendarRoute && nav) {
-      nav.navigate({
-        key: calendarRoute.key,
+    if (state?.routeNames?.includes('MedCalendar')) {
+      parent?.navigate({
+        name: 'MedCalendar',
         params: { forceRefresh: Date.now() },
         merge: true,
       });
-      nav.dispatch(StackActions.popToTop());
+      parent?.dispatch(StackActions.popToTop());
     } else {
-      navigation.navigate('Лекарства', {
+      parent?.getParent?.()?.navigate('Лекарства', {
         screen: 'MedCalendar',
         params: { forceRefresh: Date.now() },
       });

--- a/MedTrackApp/src/screens/Medications/Medications.tsx
+++ b/MedTrackApp/src/screens/Medications/Medications.tsx
@@ -101,22 +101,16 @@ const Medications: React.FC = () => {
   });
 
   const navigateToCalendar = () => {
-    const parent = navigation.getParent?.();
-    const state = parent?.getState?.();
+    navigation.dispatch(StackActions.popToTop());
 
-    if (state?.routeNames?.includes('MedCalendar')) {
-      parent?.navigate({
-        name: 'MedCalendar',
-        params: { forceRefresh: Date.now() },
-        merge: true,
-      });
-      parent?.dispatch(StackActions.popToTop());
-    } else {
-      parent?.getParent?.()?.navigate('Лекарства', {
+    navigation.getParent()?.navigate({
+      name: 'Лекарства',
+      params: {
         screen: 'MedCalendar',
         params: { forceRefresh: Date.now() },
-      });
-    }
+      },
+      merge: true,
+    });
   };
 
   const stopCourse = async (id: number) => {

--- a/MedTrackApp/src/screens/Medications/Medications.tsx
+++ b/MedTrackApp/src/screens/Medications/Medications.tsx
@@ -106,6 +106,7 @@ const Medications: React.FC = () => {
     navigation.navigate('Лекарства', {
       screen: 'MedCalendar',
       params: { forceRefresh: Date.now() },
+      merge: true,
     });
   };
 
@@ -132,6 +133,7 @@ const Medications: React.FC = () => {
     navigation.navigate('Лекарства', {
       screen: 'MedCalendar',
       params: { forceRefresh: Date.now() },
+      merge: true,
     });
   };
 

--- a/MedTrackApp/src/screens/Medications/Medications.tsx
+++ b/MedTrackApp/src/screens/Medications/Medications.tsx
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
-import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import { useNavigation, useFocusEffect, StackActions } from '@react-navigation/native';
 import { useMedications } from '../../hooks/useMedications';
 import { useCourses, useReminders } from '../../hooks';
 import { MedicationCourse } from '../../types';
@@ -101,16 +101,23 @@ const Medications: React.FC = () => {
   });
 
   const navigateToCalendar = () => {
-    const state = navigation.getState();
-    const calendarRoute = state.routes.find(r => r.name === 'MedCalendar');
+    let nav: any = navigation;
+    while (nav?.getState && !nav.getState().routes.find((r: any) => r.name === 'MedCalendar')) {
+      const parent = nav.getParent?.();
+      if (!parent) break;
+      nav = parent;
+    }
 
-    if (calendarRoute) {
-      navigation.navigate({
+    const state = nav?.getState?.();
+    const calendarRoute = state?.routes.find((r: any) => r.name === 'MedCalendar');
+
+    if (calendarRoute && nav) {
+      nav.navigate({
         key: calendarRoute.key,
         params: { forceRefresh: Date.now() },
         merge: true,
       });
-      navigation.goBack();
+      nav.dispatch(StackActions.popToTop());
     } else {
       navigation.navigate('Лекарства', {
         screen: 'MedCalendar',

--- a/MedTrackApp/src/screens/Medications/Medications.tsx
+++ b/MedTrackApp/src/screens/Medications/Medications.tsx
@@ -100,12 +100,24 @@ const Medications: React.FC = () => {
     return completed || c.endDate < today;
   });
 
-  const navigateToCalendar = () =>
-    navigation.navigate({
-      name: 'MedCalendar',
-      params: { forceRefresh: Date.now() },
-      merge: true,
-    });
+  const navigateToCalendar = () => {
+    const state = navigation.getState();
+    const calendarRoute = state.routes.find(r => r.name === 'MedCalendar');
+
+    if (calendarRoute) {
+      navigation.navigate({
+        key: calendarRoute.key,
+        params: { forceRefresh: Date.now() },
+        merge: true,
+      });
+      navigation.goBack();
+    } else {
+      navigation.navigate('Лекарства', {
+        screen: 'MedCalendar',
+        params: { forceRefresh: Date.now() },
+      });
+    }
+  };
 
   const stopCourse = async (id: number) => {
     await removeCourse(id);

--- a/MedTrackApp/src/screens/Medications/Medications.tsx
+++ b/MedTrackApp/src/screens/Medications/Medications.tsx
@@ -100,14 +100,17 @@ const Medications: React.FC = () => {
     return completed || c.endDate < today;
   });
 
-  const stopCourse = async (id: number) => {
-    await removeCourse(id);
-    await deleteByCourse(id);
-    navigation.navigate('Лекарства', {
-      screen: 'MedCalendar',
+  const navigateToCalendar = () =>
+    navigation.navigate({
+      name: 'MedCalendar',
       params: { forceRefresh: Date.now() },
       merge: true,
     });
+
+  const stopCourse = async (id: number) => {
+    await removeCourse(id);
+    await deleteByCourse(id);
+    navigateToCalendar();
   };
 
   const repeatCourse = (course: MedicationCourse) => {
@@ -130,11 +133,7 @@ const Medications: React.FC = () => {
   const deleteCourse = async (id: number) => {
     await removeCourse(id);
     await deleteByCourse(id);
-    navigation.navigate('Лекарства', {
-      screen: 'MedCalendar',
-      params: { forceRefresh: Date.now() },
-      merge: true,
-    });
+    navigateToCalendar();
   };
 
   return (


### PR DESCRIPTION
## Summary
- ensure course deletion navigation reuses existing calendar screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890731451fc832f8a381a4a994173e2