### PR TITLE
feat: add body diary screen

### DIFF
--- a/MedTrackApp/src/navigation/AppNavigator.tsx
+++ b/MedTrackApp/src/navigation/AppNavigator.tsx
@@ -11,6 +11,7 @@ import AccountScreen from '../screens/AccountScreen';
 import MedCalendarScreen from '../screens/MedCalendarScreen';
 import Profile from '../screens/Profile';
 import Medications from '../screens/Medications';
+import BodyDiaryScreen from '../screens/BodyDiaryScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator();
@@ -19,6 +20,7 @@ const MainStack = () => (
   <Stack.Navigator screenOptions={{ headerShown: false }}>
     <Stack.Screen name="MainScreen" component={MainScreen} />
     <Stack.Screen name="Account" component={AccountScreen} />
+    <Stack.Screen name="BodyDiary" component={BodyDiaryScreen} />
   </Stack.Navigator>
 );
 

--- a/MedTrackApp/src/navigation/types.ts
+++ b/MedTrackApp/src/navigation/types.ts
@@ -22,4 +22,5 @@ export type RootStackParamList = {
   };
   Profile: undefined;
   Medications: undefined;
+  BodyDiary: undefined;
 };

--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -495,6 +495,13 @@ const AccountScreen: React.FC = () => {
               </View>
             </View>
 
+            <TouchableOpacity
+              style={styles.diaryButton}
+              onPress={() => navigation.navigate('BodyDiary')}
+            >
+              <Text style={styles.diaryButtonText}>Дневник тела</Text>
+            </TouchableOpacity>
+
             <TouchableOpacity style={styles.saveButton} onPress={save}>
               <Text style={styles.saveButtonText}>Сохранить</Text>
             </TouchableOpacity>

--- a/MedTrackApp/src/screens/AccountScreen/styles.ts
+++ b/MedTrackApp/src/screens/AccountScreen/styles.ts
@@ -152,6 +152,18 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     fontSize: 16,
   },
+  diaryButton: {
+    backgroundColor: '#007AFF',
+    padding: 15,
+    borderRadius: 10,
+    alignItems: 'center',
+    marginTop: 10,
+  },
+  diaryButtonText: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
   errorText: {
     color: '#FF3B30',
     marginBottom: 4,

--- a/MedTrackApp/src/screens/BodyDiaryScreen/BodyDiaryScreen.tsx
+++ b/MedTrackApp/src/screens/BodyDiaryScreen/BodyDiaryScreen.tsx
@@ -5,12 +5,13 @@ import {
   TouchableOpacity,
   TextInput,
   ScrollView,
+  Modal,
+  TouchableWithoutFeedback,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { Picker } from '@react-native-picker/picker';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   format,
@@ -60,6 +61,10 @@ const BodyDiaryScreen: React.FC = () => {
   );
   const [entry, setEntry] = useState<BodyEntry>(EMPTY_ENTRY);
   const [data, setData] = useState<Record<string, BodyEntry>>({});
+  const [goalModalVisible, setGoalModalVisible] = useState(false);
+  const [activityModalVisible, setActivityModalVisible] = useState(false);
+  const [tempGoal, setTempGoal] = useState<BodyEntry['goal']>('Поддержание формы');
+  const [tempActivity, setTempActivity] = useState<BodyEntry['activity']>('Средний');
 
   useEffect(() => {
     (async () => {
@@ -83,6 +88,26 @@ const BodyDiaryScreen: React.FC = () => {
     const newData = { ...data, [key]: entry };
     setData(newData);
     await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(newData));
+  };
+
+  const openGoalModal = () => {
+    setTempGoal(entry.goal);
+    setGoalModalVisible(true);
+  };
+
+  const confirmGoal = () => {
+    setEntry(prev => ({ ...prev, goal: tempGoal }));
+    setGoalModalVisible(false);
+  };
+
+  const openActivityModal = () => {
+    setTempActivity(entry.activity);
+    setActivityModalVisible(true);
+  };
+
+  const confirmActivity = () => {
+    setEntry(prev => ({ ...prev, activity: tempActivity }));
+    setActivityModalVisible(false);
   };
 
   const weeks = Array.from({ length: 52 }, (_, i) =>
@@ -137,23 +162,16 @@ const BodyDiaryScreen: React.FC = () => {
 
       <ScrollView contentContainerStyle={styles.form}>
         <Text style={styles.label}>Цель</Text>
-        <View style={styles.pickerWrapper}>
-          <Picker
-            selectedValue={entry.goal}
-            onValueChange={value => setEntry(prev => ({ ...prev, goal: value }))}
-            style={styles.picker}
-            dropdownIconColor="#fff"
-          >
-            <Picker.Item label="Похудение" value="Похудение" />
-            <Picker.Item label="Набор массы" value="Набор массы" />
-            <Picker.Item label="Поддержание формы" value="Поддержание формы" />
-          </Picker>
-        </View>
+        <TouchableOpacity style={styles.selector} onPress={openGoalModal}>
+          <Text style={styles.selectorText}>{entry.goal}</Text>
+        </TouchableOpacity>
 
         <Text style={styles.label}>Рост (см)</Text>
         <TextInput
           style={styles.input}
           keyboardType="numeric"
+          placeholder="0"
+          placeholderTextColor="#666"
           value={entry.height}
           onChangeText={text => setEntry(prev => ({ ...prev, height: text }))}
         />
@@ -162,6 +180,8 @@ const BodyDiaryScreen: React.FC = () => {
         <TextInput
           style={styles.input}
           keyboardType="numeric"
+          placeholder="0"
+          placeholderTextColor="#666"
           value={entry.weight}
           onChangeText={text => setEntry(prev => ({ ...prev, weight: text }))}
         />
@@ -170,6 +190,8 @@ const BodyDiaryScreen: React.FC = () => {
         <TextInput
           style={styles.input}
           keyboardType="numeric"
+          placeholder="0"
+          placeholderTextColor="#666"
           value={entry.neck}
           onChangeText={text => setEntry(prev => ({ ...prev, neck: text }))}
         />
@@ -178,6 +200,8 @@ const BodyDiaryScreen: React.FC = () => {
         <TextInput
           style={styles.input}
           keyboardType="numeric"
+          placeholder="0"
+          placeholderTextColor="#666"
           value={entry.waist}
           onChangeText={text => setEntry(prev => ({ ...prev, waist: text }))}
         />
@@ -186,30 +210,23 @@ const BodyDiaryScreen: React.FC = () => {
         <TextInput
           style={styles.input}
           keyboardType="numeric"
+          placeholder="0"
+          placeholderTextColor="#666"
           value={entry.hips}
           onChangeText={text => setEntry(prev => ({ ...prev, hips: text }))}
         />
 
         <Text style={styles.label}>Уровень физической активности</Text>
-        <View style={styles.pickerWrapper}>
-          <Picker
-            selectedValue={entry.activity}
-            onValueChange={value =>
-              setEntry(prev => ({ ...prev, activity: value }))
-            }
-            style={styles.picker}
-            dropdownIconColor="#fff"
-          >
-            <Picker.Item label="Низкий" value="Низкий" />
-            <Picker.Item label="Средний" value="Средний" />
-            <Picker.Item label="Высокий" value="Высокий" />
-          </Picker>
-        </View>
+        <TouchableOpacity style={styles.selector} onPress={openActivityModal}>
+          <Text style={styles.selectorText}>{entry.activity}</Text>
+        </TouchableOpacity>
 
         <Text style={styles.label}>Среднедневное количество шагов за неделю</Text>
         <TextInput
           style={styles.input}
           keyboardType="numeric"
+          placeholder="0"
+          placeholderTextColor="#666"
           value={entry.steps}
           onChangeText={text => setEntry(prev => ({ ...prev, steps: text }))}
         />
@@ -218,6 +235,90 @@ const BodyDiaryScreen: React.FC = () => {
           <Text style={styles.saveButtonText}>Сохранить</Text>
         </TouchableOpacity>
       </ScrollView>
+
+      {/* Goal Modal */}
+      <Modal
+        transparent
+        animationType="slide"
+        visible={goalModalVisible}
+        onRequestClose={() => setGoalModalVisible(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setGoalModalVisible(false)}>
+          <View style={styles.modalOverlay}>
+            <TouchableWithoutFeedback>
+              <View style={styles.modalContent}>
+                <View style={styles.modalHeader}>
+                  <TouchableOpacity onPress={() => setGoalModalVisible(false)}>
+                    <Text style={styles.cancelButton}>Отмена</Text>
+                  </TouchableOpacity>
+                  <Text style={styles.modalTitle}>Цель</Text>
+                  <TouchableOpacity onPress={confirmGoal}>
+                    <Text style={styles.doneButton}>Готово</Text>
+                  </TouchableOpacity>
+                </View>
+                {['Похудение', 'Набор массы', 'Поддержание формы'].map(option => (
+                  <TouchableOpacity
+                    key={option}
+                    style={styles.modalOption}
+                    onPress={() => setTempGoal(option as BodyEntry['goal'])}
+                  >
+                    <Text
+                      style={[
+                        styles.modalOptionText,
+                        tempGoal === option && styles.modalOptionTextActive,
+                      ]}
+                    >
+                      {option}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+
+      {/* Activity Modal */}
+      <Modal
+        transparent
+        animationType="slide"
+        visible={activityModalVisible}
+        onRequestClose={() => setActivityModalVisible(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setActivityModalVisible(false)}>
+          <View style={styles.modalOverlay}>
+            <TouchableWithoutFeedback>
+              <View style={styles.modalContent}>
+                <View style={styles.modalHeader}>
+                  <TouchableOpacity onPress={() => setActivityModalVisible(false)}>
+                    <Text style={styles.cancelButton}>Отмена</Text>
+                  </TouchableOpacity>
+                  <Text style={styles.modalTitle}>Уровень физической активности</Text>
+                  <TouchableOpacity onPress={confirmActivity}>
+                    <Text style={styles.doneButton}>Готово</Text>
+                  </TouchableOpacity>
+                </View>
+                {['Низкий', 'Средний', 'Высокий'].map(option => (
+                  <TouchableOpacity
+                    key={option}
+                    style={styles.modalOption}
+                    onPress={() => setTempActivity(option as BodyEntry['activity'])}
+                  >
+                    <Text
+                      style={[
+                        styles.modalOptionText,
+                        tempActivity === option && styles.modalOptionTextActive,
+                      ]}
+                    >
+                      {option}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
     </SafeAreaView>
   );
 };

--- a/MedTrackApp/src/screens/BodyDiaryScreen/BodyDiaryScreen.tsx
+++ b/MedTrackApp/src/screens/BodyDiaryScreen/BodyDiaryScreen.tsx
@@ -1,0 +1,226 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  TextInput,
+  ScrollView,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { Picker } from '@react-native-picker/picker';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  format,
+  startOfWeek,
+  endOfWeek,
+  addWeeks,
+  isSameWeek,
+} from 'date-fns';
+import { ru } from 'date-fns/locale';
+
+import { RootStackParamList } from '../../navigation';
+import { styles } from './styles';
+
+interface BodyEntry {
+  goal: 'Похудение' | 'Набор массы' | 'Поддержание формы';
+  height: string;
+  weight: string;
+  neck: string;
+  waist: string;
+  hips: string;
+  activity: 'Низкий' | 'Средний' | 'Высокий';
+  steps: string;
+}
+
+const EMPTY_ENTRY: BodyEntry = {
+  goal: 'Поддержание формы',
+  height: '',
+  weight: '',
+  neck: '',
+  waist: '',
+  hips: '',
+  activity: 'Средний',
+  steps: '',
+};
+
+const STORAGE_KEY = 'bodyDiary';
+
+const getWeekKey = (date: Date) =>
+  format(startOfWeek(date, { weekStartsOn: 1 }), 'yyyy-MM-dd');
+
+type NavProp = StackNavigationProp<RootStackParamList, 'BodyDiary'>;
+
+const BodyDiaryScreen: React.FC = () => {
+  const navigation = useNavigation<NavProp>();
+  const [selectedWeek, setSelectedWeek] = useState<Date>(
+    startOfWeek(new Date(), { weekStartsOn: 1 }),
+  );
+  const [entry, setEntry] = useState<BodyEntry>(EMPTY_ENTRY);
+  const [data, setData] = useState<Record<string, BodyEntry>>({});
+
+  useEffect(() => {
+    (async () => {
+      const json = await AsyncStorage.getItem(STORAGE_KEY);
+      const parsed = json ? JSON.parse(json) : {};
+      setData(parsed);
+    })();
+  }, []);
+
+  useEffect(() => {
+    const key = getWeekKey(selectedWeek);
+    if (data[key]) {
+      setEntry(data[key]);
+    } else {
+      setEntry(EMPTY_ENTRY);
+    }
+  }, [selectedWeek, data]);
+
+  const save = async () => {
+    const key = getWeekKey(selectedWeek);
+    const newData = { ...data, [key]: entry };
+    setData(newData);
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(newData));
+  };
+
+  const weeks = Array.from({ length: 52 }, (_, i) =>
+    addWeeks(startOfWeek(new Date(), { weekStartsOn: 1 }), i - 26),
+  );
+
+  const renderWeekLabel = (date: Date) => {
+    const start = date;
+    const end = endOfWeek(date, { weekStartsOn: 1 });
+    const sameMonth = start.getMonth() === end.getMonth();
+    const startFmt = sameMonth
+      ? format(start, 'd', { locale: ru })
+      : format(start, 'd MMMM', { locale: ru });
+    const endFmt = format(end, 'd MMMM', { locale: ru });
+    return sameMonth
+      ? `${startFmt}–${endFmt}`
+      : `${startFmt} – ${endFmt}`;
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Icon name="arrow-left" size={24} color="white" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Дневник тела</Text>
+        <View style={{ width: 24 }} />
+      </View>
+
+      <View style={styles.weekPicker}>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          {weeks.map(week => {
+            const key = getWeekKey(week);
+            const isSelected = isSameWeek(week, selectedWeek, {
+              weekStartsOn: 1,
+            });
+            return (
+              <TouchableOpacity
+                key={key}
+                style={[
+                  styles.weekItem,
+                  isSelected && styles.weekItemActive,
+                ]}
+                onPress={() => setSelectedWeek(week)}
+              >
+                <Text style={styles.weekItemText}>{renderWeekLabel(week)}</Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.form}>
+        <Text style={styles.label}>Цель</Text>
+        <View style={styles.pickerWrapper}>
+          <Picker
+            selectedValue={entry.goal}
+            onValueChange={value => setEntry(prev => ({ ...prev, goal: value }))}
+            style={styles.picker}
+            dropdownIconColor="#fff"
+          >
+            <Picker.Item label="Похудение" value="Похудение" />
+            <Picker.Item label="Набор массы" value="Набор массы" />
+            <Picker.Item label="Поддержание формы" value="Поддержание формы" />
+          </Picker>
+        </View>
+
+        <Text style={styles.label}>Рост (см)</Text>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={entry.height}
+          onChangeText={text => setEntry(prev => ({ ...prev, height: text }))}
+        />
+
+        <Text style={styles.label}>Вес (кг)</Text>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={entry.weight}
+          onChangeText={text => setEntry(prev => ({ ...prev, weight: text }))}
+        />
+
+        <Text style={styles.label}>Обхват шеи (см)</Text>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={entry.neck}
+          onChangeText={text => setEntry(prev => ({ ...prev, neck: text }))}
+        />
+
+        <Text style={styles.label}>Обхват талии (см)</Text>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={entry.waist}
+          onChangeText={text => setEntry(prev => ({ ...prev, waist: text }))}
+        />
+
+        <Text style={styles.label}>Обхват бедер (см)</Text>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={entry.hips}
+          onChangeText={text => setEntry(prev => ({ ...prev, hips: text }))}
+        />
+
+        <Text style={styles.label}>Уровень физической активности</Text>
+        <View style={styles.pickerWrapper}>
+          <Picker
+            selectedValue={entry.activity}
+            onValueChange={value =>
+              setEntry(prev => ({ ...prev, activity: value }))
+            }
+            style={styles.picker}
+            dropdownIconColor="#fff"
+          >
+            <Picker.Item label="Низкий" value="Низкий" />
+            <Picker.Item label="Средний" value="Средний" />
+            <Picker.Item label="Высокий" value="Высокий" />
+          </Picker>
+        </View>
+
+        <Text style={styles.label}>Среднедневное количество шагов за неделю</Text>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={entry.steps}
+          onChangeText={text => setEntry(prev => ({ ...prev, steps: text }))}
+        />
+
+        <TouchableOpacity style={styles.saveButton} onPress={save}>
+          <Text style={styles.saveButtonText}>Сохранить</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default BodyDiaryScreen;
+

--- a/MedTrackApp/src/screens/BodyDiaryScreen/BodyDiaryScreen.tsx
+++ b/MedTrackApp/src/screens/BodyDiaryScreen/BodyDiaryScreen.tsx
@@ -293,7 +293,7 @@ const BodyDiaryScreen: React.FC = () => {
                   <TouchableOpacity onPress={() => setActivityModalVisible(false)}>
                     <Text style={styles.cancelButton}>Отмена</Text>
                   </TouchableOpacity>
-                  <Text style={styles.modalTitle}>Уровень физической активности</Text>
+                  <Text style={styles.modalTitle}>Уровень физ. активности</Text>
                   <TouchableOpacity onPress={confirmActivity}>
                     <Text style={styles.doneButton}>Готово</Text>
                   </TouchableOpacity>

--- a/MedTrackApp/src/screens/BodyDiaryScreen/index.ts
+++ b/MedTrackApp/src/screens/BodyDiaryScreen/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BodyDiaryScreen';

--- a/MedTrackApp/src/screens/BodyDiaryScreen/styles.ts
+++ b/MedTrackApp/src/screens/BodyDiaryScreen/styles.ts
@@ -1,0 +1,73 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#121212',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+  },
+  headerTitle: {
+    flex: 1,
+    textAlign: 'center',
+    color: 'white',
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  weekPicker: {
+    paddingHorizontal: 10,
+    paddingBottom: 10,
+  },
+  weekItem: {
+    backgroundColor: '#1E1E1E',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    marginHorizontal: 4,
+  },
+  weekItemActive: {
+    backgroundColor: '#007AFF',
+  },
+  weekItemText: {
+    color: 'white',
+  },
+  form: {
+    paddingHorizontal: 20,
+    paddingBottom: 40,
+  },
+  label: {
+    color: '#aaa',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  input: {
+    backgroundColor: '#1E1E1E',
+    color: 'white',
+    padding: 10,
+    borderRadius: 8,
+  },
+  pickerWrapper: {
+    backgroundColor: '#1E1E1E',
+    borderRadius: 8,
+  },
+  picker: {
+    color: 'white',
+  },
+  saveButton: {
+    backgroundColor: '#007AFF',
+    padding: 15,
+    borderRadius: 10,
+    alignItems: 'center',
+    marginTop: 20,
+    marginBottom: 30,
+  },
+  saveButtonText: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+});
+

--- a/MedTrackApp/src/screens/BodyDiaryScreen/styles.ts
+++ b/MedTrackApp/src/screens/BodyDiaryScreen/styles.ts
@@ -22,14 +22,16 @@ export const styles = StyleSheet.create({
     paddingBottom: 10,
   },
   weekItem: {
-    backgroundColor: '#1E1E1E',
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderRadius: 8,
     marginHorizontal: 4,
+    borderWidth: 1,
+    borderColor: '#2C2C2C',
   },
   weekItemActive: {
     backgroundColor: '#007AFF',
+    borderColor: '#007AFF',
   },
   weekItemText: {
     color: 'white',
@@ -48,12 +50,17 @@ export const styles = StyleSheet.create({
     color: 'white',
     padding: 10,
     borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#555',
   },
-  pickerWrapper: {
+  selector: {
     backgroundColor: '#1E1E1E',
     borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#555',
+    padding: 12,
   },
-  picker: {
+  selectorText: {
     color: 'white',
   },
   saveButton: {
@@ -68,6 +75,58 @@ export const styles = StyleSheet.create({
     color: 'white',
     fontWeight: 'bold',
     fontSize: 16,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    backgroundColor: '#2C2C2C',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingBottom: 20,
+    alignItems: 'center',
+    width: '100%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 15,
+    paddingHorizontal: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: '#3A3A3A',
+    width: '100%',
+  },
+  modalTitle: {
+    color: 'white',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  cancelButton: {
+    color: '#FF3B30',
+    fontSize: 16,
+    paddingRight: 8,
+  },
+  doneButton: {
+    color: '#007AFF',
+    fontSize: 16,
+    fontWeight: 'bold',
+    paddingLeft: 8,
+  },
+  modalOption: {
+    paddingVertical: 12,
+    width: '100%',
+    alignItems: 'center',
+  },
+  modalOptionText: {
+    color: 'white',
+    fontSize: 16,
+  },
+  modalOptionTextActive: {
+    color: '#007AFF',
+    fontWeight: 'bold',
   },
 });
 


### PR DESCRIPTION
## Summary
- add navigation to BodyDiaryScreen and expose it in main stack
- add button on profile screen to open body diary
- implement BodyDiaryScreen for weekly body measurement tracking

## Testing
- `npm test`
- `npm run lint` *(fails: 'jest' is not defined and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6890dd509f84832fb796e3a43a8b3e6a