### PR TITLE
feat: add floating save button

### DIFF
--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -21,7 +21,7 @@ import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/dat
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import MaskInput from 'react-native-mask-input';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { format } from 'date-fns';
@@ -127,7 +127,6 @@ const AccountScreen: React.FC = () => {
   const [saveButtonY, setSaveButtonY] = useState<number | null>(null);
   const [showFloating, setShowFloating] = useState(true);
   const fadeAnim = useRef(new Animated.Value(1)).current;
-  const insets = useSafeAreaInsets();
 
   useEffect(() => {
     Animated.timing(fadeAnim, {
@@ -618,7 +617,7 @@ const AccountScreen: React.FC = () => {
               styles.floatingButton,
               {
                 opacity: fadeAnim,
-                bottom: insets.bottom + 4,
+                bottom: 4,
               },
             ]}
             pointerEvents={showFloating ? 'auto' : 'none'}

--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -618,7 +618,7 @@ const AccountScreen: React.FC = () => {
               styles.floatingButton,
               {
                 opacity: fadeAnim,
-                bottom: insets.bottom + 12,
+                bottom: insets.bottom + 4,
               },
             ]}
             pointerEvents={showFloating ? 'auto' : 'none'}

--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -22,7 +22,6 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import MaskInput from 'react-native-mask-input';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { format } from 'date-fns';
@@ -128,7 +127,6 @@ const AccountScreen: React.FC = () => {
   const [saveButtonY, setSaveButtonY] = useState<number | null>(null);
   const [showFloating, setShowFloating] = useState(true);
   const fadeAnim = useRef(new Animated.Value(1)).current;
-  const tabBarHeight = useBottomTabBarHeight();
   const insets = useSafeAreaInsets();
 
   useEffect(() => {
@@ -620,7 +618,7 @@ const AccountScreen: React.FC = () => {
               styles.floatingButton,
               {
                 opacity: fadeAnim,
-                bottom: Math.max(tabBarHeight, insets.bottom) + 8,
+                bottom: insets.bottom + 12,
               },
             ]}
             pointerEvents={showFloating ? 'auto' : 'none'}

--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -21,7 +21,7 @@ import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/dat
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import MaskInput from 'react-native-mask-input';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -129,6 +129,7 @@ const AccountScreen: React.FC = () => {
   const [showFloating, setShowFloating] = useState(true);
   const fadeAnim = useRef(new Animated.Value(1)).current;
   const tabBarHeight = useBottomTabBarHeight();
+  const insets = useSafeAreaInsets();
 
   useEffect(() => {
     Animated.timing(fadeAnim, {
@@ -617,7 +618,10 @@ const AccountScreen: React.FC = () => {
           <Animated.View
             style={[
               styles.floatingButton,
-              { opacity: fadeAnim, bottom: tabBarHeight + 16 },
+              {
+                opacity: fadeAnim,
+                bottom: Math.max(tabBarHeight, insets.bottom) + 8,
+              },
             ]}
             pointerEvents={showFloating ? 'auto' : 'none'}
           >

--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -21,7 +21,8 @@ import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/dat
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import MaskInput from 'react-native-mask-input';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { format } from 'date-fns';
@@ -127,7 +128,7 @@ const AccountScreen: React.FC = () => {
   const [saveButtonY, setSaveButtonY] = useState<number | null>(null);
   const [showFloating, setShowFloating] = useState(true);
   const fadeAnim = useRef(new Animated.Value(1)).current;
-  const insets = useSafeAreaInsets();
+  const tabBarHeight = useBottomTabBarHeight();
 
   useEffect(() => {
     Animated.timing(fadeAnim, {
@@ -616,7 +617,7 @@ const AccountScreen: React.FC = () => {
           <Animated.View
             style={[
               styles.floatingButton,
-              { opacity: fadeAnim, bottom: insets.bottom + 20 },
+              { opacity: fadeAnim, bottom: tabBarHeight + 16 },
             ]}
             pointerEvents={showFloating ? 'auto' : 'none'}
           >

--- a/MedTrackApp/src/screens/AccountScreen/styles.ts
+++ b/MedTrackApp/src/screens/AccountScreen/styles.ts
@@ -166,6 +166,11 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     fontSize: 16,
   },
+  floatingButton: {
+    position: 'absolute',
+    left: 20,
+    right: 20,
+  },
   diaryButton: {
     backgroundColor: '#007AFF',
     padding: 15,


### PR DESCRIPTION
## Summary
- show a floating Save button on Account screen
- fade out floating button when original save button becomes visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891049cda40832fae26828f71ce52c3