### PR TITLE
feat: modernize main screen shortcut cards

### DIFF
--- a/MedTrackApp/src/screens/MainScreen/MainScreen.tsx
+++ b/MedTrackApp/src/screens/MainScreen/MainScreen.tsx
@@ -1,5 +1,15 @@
-import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, Image, ScrollView, Alert, ImageBackground } from 'react-native';
+import React, { useState, useRef } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Image,
+  Alert,
+  ImageBackground,
+  useColorScheme,
+  Pressable,
+  Animated,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -18,6 +28,8 @@ const MainScreen: React.FC = () => {
   const { percentage, reloadStats } = useAdherence();
   const [userName, setUserName] = useState<string | undefined>();
   const [userImage, setUserImage] = useState<string | undefined>();
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
 
   useFocusEffect(
     React.useCallback(() => {
@@ -60,6 +72,61 @@ const MainScreen: React.FC = () => {
     }
   };
 
+  const FeatureItem: React.FC<{ feature: { title: string; icon: string; tab?: string } }> = ({ feature }) => {
+    const scale = useRef(new Animated.Value(1)).current;
+    return (
+      <Pressable
+        onPress={() => handleFeaturePress(feature)}
+        android_ripple={{
+          color: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)',
+          borderless: false,
+        }}
+        onPressIn={() =>
+          Animated.spring(scale, {
+            toValue: 0.97,
+            useNativeDriver: true,
+          }).start()
+        }
+        onPressOut={() =>
+          Animated.spring(scale, {
+            toValue: 1,
+            useNativeDriver: true,
+          }).start()
+        }
+        style={styles.featurePressable}
+      >
+        <Animated.View style={{ transform: [{ scale }] }}>
+          <ImageBackground
+            source={undefined}
+            style={[
+              styles.featureCard,
+              isDark ? styles.featureCardDark : styles.featureCardLight,
+            ]}
+            imageStyle={styles.featureCardImage}
+          >
+            <View style={styles.featureContent}>
+              <Icon
+                name={feature.icon as any}
+                size={32}
+                color={isDark ? '#fff' : '#000'}
+                style={styles.featureIcon}
+              />
+              <Text
+                style={[
+                  styles.featureLabel,
+                  isDark ? styles.featureLabelDark : styles.featureLabelLight,
+                ]}
+                numberOfLines={2}
+              >
+                {feature.title}
+              </Text>
+            </View>
+          </ImageBackground>
+        </Animated.View>
+      </Pressable>
+    );
+  };
+
   const isPro = true; // placeholder
 
   const getAdherenceColor = (value: number) => {
@@ -90,7 +157,10 @@ const MainScreen: React.FC = () => {
   };
 
   return (
-    <SafeAreaView edges={['top']} style={styles.container}>
+    <SafeAreaView
+      edges={['top']}
+      style={[styles.container, isDark ? styles.containerDark : styles.containerLight]}
+    >
       <TouchableOpacity style={styles.profileRow} onPress={() => navigation.navigate('Account')} activeOpacity={0.7}>
         <View style={styles.avatar}>{renderAvatar()}</View>
         <View style={styles.infoRow}>
@@ -103,20 +173,9 @@ const MainScreen: React.FC = () => {
       </TouchableOpacity>
 
       <View style={styles.featuresContainer}>
-        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          {features.map((feature) => (
-            <TouchableOpacity key={feature.title} activeOpacity={0.8} onPress={() => handleFeaturePress(feature)}>
-              <ImageBackground source={undefined} style={styles.featureCard} imageStyle={styles.featureCardImage}>
-                <View style={styles.featureContent}>
-                  <Icon name={feature.icon as any} size={40} color="#fff" style={styles.featureIcon} />
-                  <Text style={styles.featureLabel} numberOfLines={2}>
-                    {feature.title}
-                  </Text>
-                </View>
-              </ImageBackground>
-            </TouchableOpacity>
-          ))}
-        </ScrollView>
+        {features.map((feature) => (
+          <FeatureItem key={feature.title} feature={feature} />
+        ))}
       </View>
 
       <View style={styles.adherenceWrapper}>

--- a/MedTrackApp/src/screens/MainScreen/styles.ts
+++ b/MedTrackApp/src/screens/MainScreen/styles.ts
@@ -3,9 +3,14 @@ import { StyleSheet } from 'react-native';
 export const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#121212',
     paddingHorizontal: 20,
     paddingTop: 10,
+  },
+  containerDark: {
+    backgroundColor: '#121212',
+  },
+  containerLight: {
+    backgroundColor: '#FFFFFF',
   },
   profileRow: {
     flexDirection: 'row',
@@ -53,21 +58,37 @@ export const styles = StyleSheet.create({
     marginLeft: 10,
   },
   featuresContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
     paddingVertical: 10,
     marginBottom: 20,
   },
-  featureCard: {
-    width: 110,
-    height: 110,
-    backgroundColor: '#1E1E1E',
-    borderRadius: 10,
-    overflow: 'hidden',
+  featurePressable: {
+    borderRadius: 16,
     marginRight: 12,
+    marginBottom: 12,
+    overflow: 'hidden',
+  },
+  featureCard: {
+    width: 96,
+    height: 96,
+    borderRadius: 16,
+    borderWidth: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
     shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.2,
-    shadowRadius: 1.41,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
     elevation: 2,
+  },
+  featureCardDark: {
+    backgroundColor: '#1E1E1E',
+    borderColor: 'rgba(255,255,255,0.2)',
+  },
+  featureCardLight: {
+    backgroundColor: '#F2F2F2',
+    borderColor: 'rgba(0,0,0,0.2)',
   },
   featureContent: {
     flex: 1,
@@ -75,15 +96,21 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
   },
   featureCardImage: {
-    borderRadius: 10,
+    borderRadius: 16,
   },
   featureIcon: {
-    marginBottom: 8,
+    marginBottom: 6,
   },
   featureLabel: {
-    color: '#fff',
     textAlign: 'center',
-    fontSize: 14,
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  featureLabelDark: {
+    color: '#fff',
+  },
+  featureLabelLight: {
+    color: '#000',
   },
   adherenceWrapper: {
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- restyled shortcut cards on the main screen with rounded corners, borders and subtle shadows
- added theme awareness for light/dark modes and prepared for background images
- added press animation and flex-wrapping layout for responsive story-style cards

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook useEffect has a missing dependency and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6891b12fda24832fb447f730e47a9145