### PR TITLE
fix: improve product basket label readability

### DIFF
--- a/MedTrackApp/src/screens/MainScreen/MainScreen.tsx
+++ b/MedTrackApp/src/screens/MainScreen/MainScreen.tsx
@@ -122,6 +122,9 @@ const MainScreen: React.FC = () => {
                   styles.featureLabel,
                   feature.background && [styles.featureLabelImage, { color: '#FFFFFF' }],
                 ]}
+                numberOfLines={2}
+                adjustsFontSizeToFit
+                minimumFontScale={0.8}
               >
                 {feature.title}
               </Text>

--- a/MedTrackApp/src/screens/MainScreen/styles.ts
+++ b/MedTrackApp/src/screens/MainScreen/styles.ts
@@ -105,6 +105,8 @@ export const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '500',
     marginTop: 6,
+    width: '100%',
+    textBreakStrategy: 'simple',
   },
   featureLabelImage: {
     marginTop: 0,


### PR DESCRIPTION
## Summary
- avoid awkward word breaks in feature card labels
- ensure labels only break between words

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892269c9844832f9a6726ad87eaced0