### PR TITLE
Fix grocery basket card label wrapping

### DIFF
--- a/MedTrackApp/src/screens/MainScreen/MainScreen.tsx
+++ b/MedTrackApp/src/screens/MainScreen/MainScreen.tsx
@@ -122,6 +122,10 @@ const MainScreen: React.FC = () => {
                   styles.featureLabel,
                   feature.background && [styles.featureLabelImage, { color: '#FFFFFF' }],
                 ]}
+                numberOfLines={2}
+                ellipsizeMode="clip"
+                textBreakStrategy="simple"
+                lineBreakStrategyIOS="none"
               >
                 {feature.title}
               </Text>

--- a/MedTrackApp/src/screens/MainScreen/styles.ts
+++ b/MedTrackApp/src/screens/MainScreen/styles.ts
@@ -105,6 +105,7 @@ export const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '500',
     marginTop: 6,
+    width: '100%',
   },
   featureLabelImage: {
     marginTop: 0,


### PR DESCRIPTION
## Summary
- prevent word-splitting and truncation for the "Продуктовые корзины" card label
- allow full-width wrapping of feature labels to show all text

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook useEffect has a missing dependency and other warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6892269c9844832f9a6726ad87eaced0