### PR TITLE
fix: prevent label word break in feature card

### DIFF
--- a/MedTrackApp/src/screens/MainScreen/styles.ts
+++ b/MedTrackApp/src/screens/MainScreen/styles.ts
@@ -89,7 +89,9 @@ export const styles = StyleSheet.create({
   },
   featureContentBottom: {
     justifyContent: 'flex-end',
-    padding: 8,
+    paddingTop: 8,
+    paddingBottom: 8,
+    paddingHorizontal: 2,
   },
   iconWrapper: {
     width: 48,
@@ -105,6 +107,7 @@ export const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '500',
     marginTop: 6,
+    android_hyphenationFrequency: 'none',
   },
   featureLabelImage: {
     marginTop: 0,


### PR DESCRIPTION
## Summary
- avoid breaking words inside the "Продуктовые корзины" feature label
- keep label at bottom by widening padding and disabling Android hyphenation

## Testing
- `npm test`
- `npm run lint` *(fails: 'jest' is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6892269c9844832f9a6726ad87eaced0