### PR TITLE
refactor: resize progress cards

### DIFF
--- a/MedTrackApp/jestSetup.js
+++ b/MedTrackApp/jestSetup.js
@@ -1,11 +1,14 @@
+/* eslint-env jest */
 import '@react-native-async-storage/async-storage/jest/async-storage-mock';
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
 );
 jest.mock('react-native/Libraries/Interaction/InteractionManager', () => {
   return {
-    runAfterInteractions: jest.fn(cb => {
-      if (cb) cb();
+    runAfterInteractions: jest.fn((cb) => {
+      if (cb) {
+        cb();
+      }
       return { then: jest.fn() };
     }),
     createInteractionHandle: jest.fn(() => 0),

--- a/MedTrackApp/src/components/CategorySummaryCard.tsx
+++ b/MedTrackApp/src/components/CategorySummaryCard.tsx
@@ -58,12 +58,11 @@ const CategorySummaryCard: React.FC<CategorySummaryCardProps> = ({
             height={innerSize}
             stroke={color}
             strokeWidth={strokeWidth}
-            strokeDasharray={perimeter}
+            strokeDasharray={`${perimeter} ${perimeter}`}
             strokeDashoffset={strokeDashoffset}
             fill="transparent"
             rx={borderRadius}
             ry={borderRadius}
-            transform={`rotate(-90 ${size / 2} ${size / 2})`}
           />
         </Svg>
       )}

--- a/MedTrackApp/src/components/CategorySummaryCard.tsx
+++ b/MedTrackApp/src/components/CategorySummaryCard.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import Svg, { Rect } from 'react-native-svg';
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, LayoutChangeEvent } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 export type CategorySummaryCardProps = {
@@ -14,12 +14,12 @@ const CategorySummaryCard: React.FC<CategorySummaryCardProps> = ({
   label,
   percentage,
 }) => {
-  const size = 80;
-  const strokeWidth = 4;
-  const radius = 10;
+  const [size, setSize] = useState(0);
 
-  const perimeter = 4 * (size - strokeWidth);
-  const strokeDashoffset = perimeter - (perimeter * percentage) / 100;
+  const strokeWidth = size * 0.12;
+  const radius = size / 2 - strokeWidth / 2;
+  const circumference = 2 * Math.PI * radius;
+  const strokeDashoffset = circumference - (circumference * percentage) / 100;
 
   const getColor = (value: number) => {
     if (value >= 80) return '#4CAF50';
@@ -28,34 +28,39 @@ const CategorySummaryCard: React.FC<CategorySummaryCardProps> = ({
   };
   const color = getColor(percentage);
 
+  const onLayout = (e: LayoutChangeEvent) => {
+    const newSize = e.nativeEvent.layout.width;
+    if (newSize !== size) {
+      setSize(newSize);
+    }
+  };
+
   return (
-    <View style={styles.wrapper}>
-      <Svg height={size} width={size} style={styles.progress}>
-        <Rect
-          x={strokeWidth / 2}
-          y={strokeWidth / 2}
-          width={size - strokeWidth}
-          height={size - strokeWidth}
-          rx={radius}
-          ry={radius}
-          stroke="#2C2C2C"
-          strokeWidth={strokeWidth}
-          fill="transparent"
-        />
-        <Rect
-          x={strokeWidth / 2}
-          y={strokeWidth / 2}
-          width={size - strokeWidth}
-          height={size - strokeWidth}
-          rx={radius}
-          ry={radius}
-          stroke={color}
-          strokeWidth={strokeWidth}
-          strokeDasharray={perimeter}
-          strokeDashoffset={strokeDashoffset}
-          fill="transparent"
-        />
-      </Svg>
+    <View style={[styles.wrapper, { padding: strokeWidth / 2 }]} onLayout={onLayout}>
+      {size > 0 && (
+        <Svg height={size} width={size} style={styles.progress}>
+          <Circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            stroke="#2C2C2C"
+            strokeWidth={strokeWidth}
+            fill="transparent"
+          />
+          <Circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            stroke={color}
+            strokeWidth={strokeWidth}
+            strokeDasharray={circumference}
+            strokeDashoffset={strokeDashoffset}
+            strokeLinecap="round"
+            fill="transparent"
+            transform={`rotate(-90, ${size / 2}, ${size / 2})`}
+          />
+        </Svg>
+      )}
       <View style={styles.card}>
         <Icon name={icon} size={26} color="#fff" />
         <Text style={styles.label}>{label}</Text>
@@ -66,10 +71,8 @@ const CategorySummaryCard: React.FC<CategorySummaryCardProps> = ({
 
 const styles = StyleSheet.create({
   wrapper: {
-    width: 80,
-    height: 80,
-    marginHorizontal: 5,
-    padding: 2,
+    flex: 1,
+    aspectRatio: 1,
   },
   progress: {
     position: 'absolute',

--- a/MedTrackApp/src/components/CategorySummaryCard.tsx
+++ b/MedTrackApp/src/components/CategorySummaryCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, LayoutChangeEvent } from 'react-native';
+import Svg, { Rect } from 'react-native-svg';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 export type CategorySummaryCardProps = {
@@ -23,8 +24,12 @@ const CategorySummaryCard: React.FC<CategorySummaryCardProps> = ({
   };
 
   const thickness = size * 0.1;
-  const borderRadius = 10;
-  const innerRadius = Math.max(0, borderRadius - thickness / 2);
+  const outerRadius = size * 0.25;
+  const cardRadius = Math.max(0, outerRadius - thickness);
+  const pathRadius = Math.max(0, outerRadius - thickness / 2);
+  const rectSize = size - thickness;
+  const perimeter =
+    4 * (rectSize - 2 * pathRadius) + 2 * Math.PI * pathRadius;
 
   const getColor = (value: number) => {
     if (value >= 80) return '#4CAF50';
@@ -33,98 +38,50 @@ const CategorySummaryCard: React.FC<CategorySummaryCardProps> = ({
   };
   const color = getColor(percentage);
 
-  // progress from 0 to 4 (number of sides)
-  const progress = Math.max(0, Math.min(percentage, 100)) / 25;
-  const sides = [
-    Math.min(progress, 1),
-    Math.min(Math.max(progress - 1, 0), 1),
-    Math.min(Math.max(progress - 2, 0), 1),
-    Math.min(Math.max(progress - 3, 0), 1),
-  ];
+  const progress = Math.max(0, Math.min(percentage, 100)) / 100;
 
   return (
     <View style={styles.wrapper} onLayout={onLayout}>
-      <View style={[styles.card, { margin: thickness, borderRadius: innerRadius }]}>
+      <View style={[styles.card, { margin: thickness, borderRadius: cardRadius }]}>
         <Icon name={icon} size={26} color="#fff" />
         <Text style={styles.label}>{label}</Text>
       </View>
       {size > 0 && (
-        <>
-          <View
-            pointerEvents="none"
-            style={[
-              styles.track,
-              {
-                borderWidth: thickness,
-                borderRadius,
-              },
-            ]}
+        <Svg
+          pointerEvents="none"
+          width={size}
+          height={size}
+          style={StyleSheet.absoluteFill}
+        >
+          <Rect
+            x={thickness / 2}
+            y={thickness / 2}
+            width={size - thickness}
+            height={size - thickness}
+            rx={pathRadius}
+            ry={pathRadius}
+            stroke="#2C2C2C"
+            strokeWidth={thickness}
+            fill="none"
           />
-          {/* Top edge */}
-          <View
-            pointerEvents="none"
-            style={[
-              styles.edge,
-              {
-                top: 0,
-                left: 0,
-                height: thickness,
-                width: `${sides[0] * 100}%`,
-                backgroundColor: color,
-                borderTopLeftRadius: borderRadius,
-                borderTopRightRadius: sides[0] === 1 ? borderRadius : 0,
-              },
-            ]}
-          />
-          {/* Right edge */}
-          <View
-            pointerEvents="none"
-            style={[
-              styles.edge,
-              {
-                top: 0,
-                right: 0,
-                width: thickness,
-                height: `${sides[1] * 100}%`,
-                backgroundColor: color,
-                borderTopRightRadius: sides[0] === 1 ? borderRadius : 0,
-                borderBottomRightRadius: sides[1] === 1 ? borderRadius : 0,
-              },
-            ]}
-          />
-          {/* Bottom edge */}
-          <View
-            pointerEvents="none"
-            style={[
-              styles.edge,
-              {
-                bottom: 0,
-                right: 0,
-                height: thickness,
-                width: `${sides[2] * 100}%`,
-                backgroundColor: color,
-                borderBottomRightRadius: sides[1] === 1 ? borderRadius : 0,
-                borderBottomLeftRadius: sides[2] === 1 ? borderRadius : 0,
-              },
-            ]}
-          />
-          {/* Left edge */}
-          <View
-            pointerEvents="none"
-            style={[
-              styles.edge,
-              {
-                left: 0,
-                bottom: 0,
-                width: thickness,
-                height: `${sides[3] * 100}%`,
-                backgroundColor: color,
-                borderBottomLeftRadius: sides[2] === 1 ? borderRadius : 0,
-                borderTopLeftRadius: sides[3] === 1 ? borderRadius : 0,
-              },
-            ]}
-          />
-        </>
+          {progress > 0 && (
+            <Rect
+              x={thickness / 2}
+              y={thickness / 2}
+              width={size - thickness}
+              height={size - thickness}
+              rx={pathRadius}
+              ry={pathRadius}
+              stroke={color}
+              strokeWidth={thickness}
+              fill="none"
+              strokeDasharray={`${perimeter} ${perimeter}`}
+              strokeDashoffset={perimeter * (1 - progress)}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          )}
+        </Svg>
       )}
     </View>
   );
@@ -134,13 +91,6 @@ const styles = StyleSheet.create({
   wrapper: {
     flex: 1,
     aspectRatio: 1,
-  },
-  track: {
-    ...StyleSheet.absoluteFillObject,
-    borderColor: '#2C2C2C',
-  },
-  edge: {
-    position: 'absolute',
   },
   card: {
     flex: 1,

--- a/MedTrackApp/src/components/CategorySummaryCard.tsx
+++ b/MedTrackApp/src/components/CategorySummaryCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, LayoutChangeEvent } from 'react-native';
-import Svg, { Circle } from 'react-native-svg';
+import Svg, { Rect } from 'react-native-svg';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 export type CategorySummaryCardProps = {
@@ -16,10 +16,11 @@ const CategorySummaryCard: React.FC<CategorySummaryCardProps> = ({
 }) => {
   const [size, setSize] = useState(0);
 
-  const strokeWidth = size * 0.12;
-  const radius = size / 2 - strokeWidth / 2;
-  const circumference = 2 * Math.PI * radius;
-  const strokeDashoffset = circumference - (circumference * percentage) / 100;
+  const strokeWidth = size * 0.1;
+  const innerSize = size - strokeWidth;
+  const borderRadius = 10;
+  const perimeter = 4 * (innerSize - borderRadius) + 2 * Math.PI * borderRadius;
+  const strokeDashoffset = perimeter - (perimeter * percentage) / 100;
 
   const getColor = (value: number) => {
     if (value >= 80) return '#4CAF50';
@@ -39,25 +40,30 @@ const CategorySummaryCard: React.FC<CategorySummaryCardProps> = ({
     <View style={[styles.wrapper, { padding: strokeWidth / 2 }]} onLayout={onLayout}>
       {size > 0 && (
         <Svg height={size} width={size} style={styles.progress}>
-          <Circle
-            cx={size / 2}
-            cy={size / 2}
-            r={radius}
+          <Rect
+            x={strokeWidth / 2}
+            y={strokeWidth / 2}
+            width={innerSize}
+            height={innerSize}
             stroke="#2C2C2C"
             strokeWidth={strokeWidth}
             fill="transparent"
+            rx={borderRadius}
+            ry={borderRadius}
           />
-          <Circle
-            cx={size / 2}
-            cy={size / 2}
-            r={radius}
+          <Rect
+            x={strokeWidth / 2}
+            y={strokeWidth / 2}
+            width={innerSize}
+            height={innerSize}
             stroke={color}
             strokeWidth={strokeWidth}
-            strokeDasharray={circumference}
+            strokeDasharray={perimeter}
             strokeDashoffset={strokeDashoffset}
-            strokeLinecap="round"
             fill="transparent"
-            transform={`rotate(-90, ${size / 2}, ${size / 2})`}
+            rx={borderRadius}
+            ry={borderRadius}
+            transform={`rotate(-90 ${size / 2} ${size / 2})`}
           />
         </Svg>
       )}

--- a/MedTrackApp/src/screens/MainScreen/styles.ts
+++ b/MedTrackApp/src/screens/MainScreen/styles.ts
@@ -117,7 +117,7 @@ export const styles = StyleSheet.create({
   },
   summaryRow: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
     marginVertical: 20,
+    gap: 12,
   },
 });

--- a/MedTrackApp/src/screens/MedCalendarScreen/WeekPickerModal.tsx
+++ b/MedTrackApp/src/screens/MedCalendarScreen/WeekPickerModal.tsx
@@ -28,7 +28,7 @@ const WeekPickerModal: React.FC<Props> = ({
     if (week > getISOWeeksInYear(new Date(year, 0, 4))) {
       setWeek(getISOWeeksInYear(new Date(year, 0, 4)));
     }
-  }, [year]);
+  }, [year, week]);
 
   useEffect(() => {
     setYear(initialYear);

--- a/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
+++ b/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
@@ -222,18 +222,21 @@ const ReminderAdd: React.FC = () => {
     setWeekdays((prev) => (prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day]));
   };
 
-  const isWeekdayInRange = (day: number) => {
-    const start = new Date(startDate);
-    const end = new Date(endDate);
-    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-      if (d.getDay() === day) return true;
-    }
-    return false;
-  };
+  const isWeekdayInRange = useCallback(
+    (day: number) => {
+      const start = new Date(startDate);
+      const end = new Date(endDate);
+      for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        if (d.getDay() === day) return true;
+      }
+      return false;
+    },
+    [startDate, endDate],
+  );
 
   useEffect(() => {
     setWeekdays((prev) => prev.filter((d) => isWeekdayInRange(d)));
-  }, [startDate, endDate]);
+  }, [isWeekdayInRange]);
 
   const handleWeekdayPress = (day: number) => {
     if (!isWeekdayInRange(day)) {


### PR DESCRIPTION
## Summary
- make progress cards expand evenly across screen
- thicken progress rings for better visibility
- add responsive spacing between category cards

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook useEffect has a missing dependency: 'isWeekdayInRange'. Either include it or remove the dependency array react-hooks/exhaustive-deps)*

------
https://chatgpt.com/codex/tasks/task_e_68935aacff54832f84f9b58151105685