### PR TITLE
feat: add diet tab

### DIFF
--- a/MedTrackApp/src/navigation/AppNavigator.tsx
+++ b/MedTrackApp/src/navigation/AppNavigator.tsx
@@ -12,6 +12,7 @@ import MedCalendarScreen from '../screens/MedCalendarScreen';
 import Profile from '../screens/Profile';
 import Medications from '../screens/Medications';
 import BodyDiaryScreen from '../screens/BodyDiaryScreen';
+import DietScreen from '../screens/DietScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator();
@@ -53,6 +54,11 @@ const AppNavigator: React.FC = () => {
           name="Лекарства"
           component={MedCalendarStack}
           options={{ tabBarIcon: ({ color }) => <Icon name="pill" size={30} color={color} /> }}
+        />
+        <Tab.Screen
+          name="Питание"
+          component={DietScreen}
+          options={{ tabBarIcon: ({ color }) => <Icon name="food" size={30} color={color} /> }}
         />
         <Tab.Screen
           name="Статистика"

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { styles } from './styles';
+
+const DietScreen: React.FC = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Питание</Text>
+    </SafeAreaView>
+  );
+};
+
+export default DietScreen;

--- a/MedTrackApp/src/screens/DietScreen/index.ts
+++ b/MedTrackApp/src/screens/DietScreen/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DietScreen';

--- a/MedTrackApp/src/screens/DietScreen/styles.ts
+++ b/MedTrackApp/src/screens/DietScreen/styles.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#121212',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: 'white',
+  },
+});


### PR DESCRIPTION
## Summary
- add blank Diet screen with centered title
- register Diet tab with food icon in bottom navigator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893a283eb90832fabf437738cb9ecf5