### PR TITLE
feat: persist profile avatar

### DIFF
--- a/MedTrackApp/__tests__/AccountScreen.test.tsx
+++ b/MedTrackApp/__tests__/AccountScreen.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * @format
+ */
+
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import AccountScreen from '../src/screens/AccountScreen/AccountScreen';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { launchImageLibrary } from 'react-native-image-picker';
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: jest.fn() }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('persists avatar after selection', async () => {
+  (launchImageLibrary as jest.Mock).mockImplementation((_options, callback) => {
+    callback({ assets: [{ uri: 'mock://avatar.png' }] });
+  });
+
+  let component: renderer.ReactTestRenderer;
+  await act(async () => {
+    component = renderer.create(<AccountScreen />);
+  });
+
+  await act(async () => {
+    component.root.findByProps({ testID: 'avatar-picker' }).props.onPress();
+  });
+
+  expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+    'userProfile',
+    expect.stringContaining('mock://avatar.png'),
+  );
+});

--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -304,11 +304,21 @@ const AccountScreen: React.FC = () => {
   };
 
   const pickAvatar = () => {
-    launchImageLibrary({ mediaType: 'photo' }, response => {
+    launchImageLibrary({ mediaType: 'photo' }, async response => {
       if (response.didCancel) return;
       const uri = response.assets && response.assets[0]?.uri;
       if (uri) {
         setProfile(prev => ({ ...prev, avatarUri: uri }));
+        try {
+          const stored = await AsyncStorage.getItem(STORAGE_KEY);
+          const parsed = stored ? JSON.parse(stored) : {};
+          await AsyncStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ ...parsed, avatarUri: uri }),
+          );
+        } catch {
+          // ignore
+        }
       }
     });
   };
@@ -387,6 +397,7 @@ const AccountScreen: React.FC = () => {
                 style={styles.avatarWrapper}
                 onPress={pickAvatar}
                 activeOpacity={0.7}
+                testID="avatar-picker"
               >
                 <View style={styles.avatar}>
                   {profile.avatarUri ? (


### PR DESCRIPTION
## Summary
- persist avatar selection to storage so it survives app restarts
- add a test covering avatar persistence

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68948c9ed508832f8bc00412c1046eb7