### PR TITLE
Add Training tab and placeholder screen

### DIFF
--- a/MedTrackApp/src/navigation/AppNavigator.tsx
+++ b/MedTrackApp/src/navigation/AppNavigator.tsx
@@ -13,6 +13,7 @@ import Profile from '../screens/Profile';
 import Medications from '../screens/Medications';
 import BodyDiaryScreen from '../screens/BodyDiaryScreen';
 import DietScreen from '../screens/DietScreen';
+import TrainingScreen from '../screens/TrainingScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator();
@@ -59,6 +60,11 @@ const AppNavigator: React.FC = () => {
           name="Питание"
           component={DietScreen}
           options={{ tabBarIcon: ({ color }) => <Icon name="food-apple" size={30} color={color} /> }}
+        />
+        <Tab.Screen
+          name="Тренировки"
+          component={TrainingScreen}
+          options={{ tabBarIcon: ({ color }) => <Icon name="dumbbell" size={30} color={color} /> }}
         />
         <Tab.Screen
           name="Статистика"

--- a/MedTrackApp/src/screens/TrainingScreen/TrainingScreen.tsx
+++ b/MedTrackApp/src/screens/TrainingScreen/TrainingScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { styles } from './styles';
+
+const TrainingScreen: React.FC = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Тренировки</Text>
+    </SafeAreaView>
+  );
+};
+
+export default TrainingScreen;

--- a/MedTrackApp/src/screens/TrainingScreen/index.ts
+++ b/MedTrackApp/src/screens/TrainingScreen/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TrainingScreen';

--- a/MedTrackApp/src/screens/TrainingScreen/styles.ts
+++ b/MedTrackApp/src/screens/TrainingScreen/styles.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#121212',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: 'white',
+  },
+});


### PR DESCRIPTION
## Summary
- add minimal Training screen with SafeAreaView and centered title
- include a new “Тренировки” tab in the bottom navigator with dumbbell icon

## Testing
- `npx jest --runInBand`
- `npm run lint` (warnings)

------
https://chatgpt.com/codex/tasks/task_e_68948f3d3d60832fa9591fd8add13ef3