### PR TITLE
Add nutrition week calendar

### DIFF
--- a/MedTrackApp/src/components/NutritionCalendar.tsx
+++ b/MedTrackApp/src/components/NutritionCalendar.tsx
@@ -1,0 +1,177 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { format, addWeeks, getISOWeek, differenceInCalendarISOWeeks } from 'date-fns';
+import { ru } from 'date-fns/locale';
+
+import { getWeekDates } from '../screens/MedCalendarScreen/utils';
+
+export type NutritionCalendarProps = {
+  value: string;
+  onChange: (date: string) => void;
+  onPrevWeek?: () => void;
+  onNextWeek?: () => void;
+  getHasFoodByDate: (date: string) => boolean;
+};
+
+const NutritionCalendar: React.FC<NutritionCalendarProps> = ({
+  value,
+  onChange,
+  onPrevWeek,
+  onNextWeek,
+  getHasFoodByDate,
+}) => {
+  const initialOffset = differenceInCalendarISOWeeks(new Date(value), new Date());
+  const [weekOffset, setWeekOffset] = useState(initialOffset);
+  const [selectedDate, setSelectedDate] = useState(value);
+
+  useEffect(() => {
+    setSelectedDate(value);
+    setWeekOffset(differenceInCalendarISOWeeks(new Date(value), new Date()));
+  }, [value]);
+
+  const weekDates = getWeekDates(weekOffset);
+  const displayDate = addWeeks(new Date(), weekOffset);
+  const monthYear = format(displayDate, 'LLLL yyyy', { locale: ru });
+  const headerText = `${monthYear.charAt(0).toUpperCase()}${monthYear.slice(1)} · ${getISOWeek(displayDate)} неделя`;
+
+  const handleDayPress = (date: string) => {
+    setSelectedDate(date);
+    onChange(date);
+  };
+
+  const handlePrevWeek = () => {
+    const offset = weekOffset - 1;
+    setWeekOffset(offset);
+    if (onPrevWeek) {
+      onPrevWeek();
+    }
+  };
+
+  const handleNextWeek = () => {
+    const offset = weekOffset + 1;
+    setWeekOffset(offset);
+    if (onNextWeek) {
+      onNextWeek();
+    }
+  };
+
+  return (
+    <View>
+      <View style={styles.weekHeader}>
+        <TouchableOpacity onPress={handlePrevWeek} style={styles.arrowButton} accessibilityRole="button">
+          <Icon name="chevron-left" size={30} color="white" />
+        </TouchableOpacity>
+        <Text style={styles.weekText}>{headerText}</Text>
+        <TouchableOpacity onPress={handleNextWeek} style={styles.arrowButton} accessibilityRole="button">
+          <Icon name="chevron-right" size={30} color="white" />
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.weekContainer}>
+        <View style={styles.weekdayRow}>
+          {weekDates.map((day, index) => (
+            <Text key={index} style={styles.weekdayText}>
+              {day.dayLabel}
+            </Text>
+          ))}
+        </View>
+        <View style={styles.datesRow}>
+          {weekDates.map(day => (
+            <TouchableOpacity
+              key={day.fullDate}
+              onPress={() => handleDayPress(day.fullDate)}
+              style={[styles.dayContainer, day.fullDate === selectedDate && styles.selectedDay]}
+            >
+              <Text
+                style={[
+                  styles.dayText,
+                  day.fullDate === selectedDate && styles.selectedDayText,
+                  day.isToday && styles.todayText,
+                ]}
+              >
+                {day.dateNumber}
+              </Text>
+              <View style={styles.dotContainer}>
+                {getHasFoodByDate(day.fullDate) && <View style={styles.dot} />}
+              </View>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  weekHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  weekText: {
+    fontSize: 18,
+    color: 'white',
+    fontWeight: 'bold',
+  },
+  arrowButton: {
+    padding: 10,
+  },
+  weekContainer: {
+    alignItems: 'center',
+    marginBottom: 15,
+  },
+  weekdayRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    width: '100%',
+    marginBottom: 5,
+  },
+  weekdayText: {
+    fontSize: 14,
+    color: 'white',
+    fontWeight: 'bold',
+    textAlign: 'center',
+    width: '14%',
+  },
+  datesRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    width: '100%',
+  },
+  dayContainer: {
+    alignItems: 'center',
+    width: '14%',
+    paddingVertical: 6,
+    borderRadius: 20,
+  },
+  selectedDay: {
+    backgroundColor: '#323232',
+  },
+  dayText: {
+    fontSize: 16,
+    color: 'white',
+    fontWeight: 'bold',
+  },
+  selectedDayText: {
+    color: 'white',
+  },
+  todayText: {
+    color: '#22C55E',
+  },
+  dotContainer: {
+    marginTop: 3,
+    minHeight: 6,
+    alignItems: 'center',
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '#22C55E',
+  },
+});
+
+export default NutritionCalendar;
+

--- a/MedTrackApp/src/components/index.ts
+++ b/MedTrackApp/src/components/index.ts
@@ -1,2 +1,3 @@
 export { default as AdherenceDisplay } from './AdherenceDisplay';
 export { default as CategorySummaryCard } from './CategorySummaryCard';
+export { default as NutritionCalendar } from './NutritionCalendar';

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -1,12 +1,30 @@
-import React from 'react';
-import { Text } from 'react-native';
+import React, { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { format } from 'date-fns';
+
+import { NutritionCalendar } from '../../components';
 import { styles } from './styles';
 
 const DietScreen: React.FC = () => {
+  const [selectedDate, setSelectedDate] = useState(
+    format(new Date(), 'yyyy-MM-dd'),
+  );
+
+  const mockFoodDates = new Set([
+    '2025-08-18',
+    '2025-08-20',
+    '2025-08-22',
+  ]);
+
+  const getHasFoodByDate = (date: string) => mockFoodDates.has(date);
+
   return (
     <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>Питание</Text>
+      <NutritionCalendar
+        value={selectedDate}
+        onChange={setSelectedDate}
+        getHasFoodByDate={getHasFoodByDate}
+      />
     </SafeAreaView>
   );
 };

--- a/MedTrackApp/src/screens/DietScreen/styles.ts
+++ b/MedTrackApp/src/screens/DietScreen/styles.ts
@@ -1,15 +1,9 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform, StatusBar } from 'react-native';
 
 export const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
     backgroundColor: '#121212',
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    color: 'white',
+    paddingTop: Platform.OS === 'ios' ? 10 : StatusBar.currentHeight,
   },
 });


### PR DESCRIPTION
## Summary
- add reusable nutrition calendar with week navigation and green accents
- integrate calendar into Diet screen with mock food data

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a702985700832f8d3aac15891df329