### PR TITLE
Add macronutrient summary to nutrition screen

### DIFF
--- a/MedTrackApp/src/components/MacronutrientSummary.tsx
+++ b/MedTrackApp/src/components/MacronutrientSummary.tsx
@@ -1,28 +1,32 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
-export type MacroValue = {
-  consumed: number;
-  target?: number;
+export type MacronutrientSummaryProps = {
+  caloriesConsumed: number;
+  caloriesTarget?: number;
+  protein: number;
+  fat: number;
+  carbs: number;
 };
 
-export type MacronutrientSummaryProps = {
-  calories: MacroValue;
-  protein: MacroValue;
-  fat: MacroValue;
-  carbs: MacroValue;
-};
+const formatNumber = (value: number) =>
+  value.toLocaleString('ru-RU', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
 
 const MacronutrientSummary: React.FC<MacronutrientSummaryProps> = ({
-  calories,
+  caloriesConsumed,
+  caloriesTarget,
   protein,
   fat,
   carbs,
 }) => {
-  const percent = calories.target
-    ? Math.round((calories.consumed / calories.target) * 100)
+  const percent = caloriesTarget
+    ? Math.round((caloriesConsumed / caloriesTarget) * 100)
     : undefined;
   const barPercent = percent !== undefined ? Math.min(percent, 100) : 0;
+
   let barColor = '#22C55E';
   if (percent !== undefined) {
     if (percent > 120) {
@@ -32,16 +36,32 @@ const MacronutrientSummary: React.FC<MacronutrientSummaryProps> = ({
     }
   }
 
-  const summaryText = [
-    `Белки ${protein.consumed}/${protein.target ?? '—'}г`,
-    `Жиры ${fat.consumed}/${fat.target ?? '—'}г`,
-    `Углеводы ${carbs.consumed}/${carbs.target ?? '—'}г`,
-    `Ккал ${calories.consumed}/${calories.target ?? '—'}`,
-  ].join(' • ');
-
   return (
     <View style={styles.container}>
-      <Text style={styles.summaryText}>{summaryText}</Text>
+      <View style={styles.topRow}>
+        <View style={styles.column}>
+          <Text style={styles.label}>Жиры</Text>
+          <Text style={styles.value}>{formatNumber(fat)}</Text>
+        </View>
+        <View style={styles.column}>
+          <Text style={styles.label}>Углев</Text>
+          <Text style={styles.value}>{formatNumber(carbs)}</Text>
+        </View>
+        <View style={styles.column}>
+          <Text style={styles.label}>Белк</Text>
+          <Text style={styles.value}>{formatNumber(protein)}</Text>
+        </View>
+        <View style={styles.column}>
+          <Text style={styles.label}>РСК</Text>
+          <Text style={styles.value}>{percent !== undefined ? `${percent}%` : '—'}</Text>
+        </View>
+        <View style={styles.column}>
+          <Text style={styles.label}>Калории</Text>
+          <Text style={[styles.value, styles.caloriesValue]}>
+            {formatNumber(caloriesConsumed)}
+          </Text>
+        </View>
+      </View>
       <View style={styles.progressRow}>
         <View style={styles.progressBar}>
           {percent !== undefined && (
@@ -64,15 +84,29 @@ const MacronutrientSummary: React.FC<MacronutrientSummaryProps> = ({
 const styles = StyleSheet.create({
   container: {
     backgroundColor: '#1E1E1E',
-    paddingVertical: 8,
-    paddingHorizontal: 12,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
     borderRadius: 8,
     marginBottom: 16,
   },
-  summaryText: {
+  topRow: {
+    flexDirection: 'row',
+  },
+  column: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  label: {
+    color: 'rgba(255,255,255,0.6)',
+    fontSize: 10,
+    marginBottom: 2,
+  },
+  value: {
     color: '#fff',
     fontSize: 12,
-    textAlign: 'center',
+  },
+  caloriesValue: {
+    fontWeight: '700',
   },
   progressRow: {
     flexDirection: 'row',
@@ -98,3 +132,4 @@ const styles = StyleSheet.create({
 });
 
 export default MacronutrientSummary;
+

--- a/MedTrackApp/src/components/MacronutrientSummary.tsx
+++ b/MedTrackApp/src/components/MacronutrientSummary.tsx
@@ -19,50 +19,43 @@ const MacronutrientSummary: React.FC<MacronutrientSummaryProps> = ({
   fat,
   carbs,
 }) => {
-  const nutrients = [
-    { label: 'Protein', ...protein },
-    { label: 'Fat', ...fat },
-    { label: 'Carbs', ...carbs },
-  ];
-
-  const rawPercent = calories.target
+  const percent = calories.target
     ? Math.round((calories.consumed / calories.target) * 100)
-    : 0;
-  const barPercent = Math.min(rawPercent, 100);
+    : undefined;
+  const barPercent = percent !== undefined ? Math.min(percent, 100) : 0;
   let barColor = '#22C55E';
-  if (rawPercent === 100) {
-    barColor = '#F59E0B';
-  } else if (rawPercent > 100) {
-    barColor = '#EF4444';
+  if (percent !== undefined) {
+    if (percent > 120) {
+      barColor = '#EF4444';
+    } else if (percent > 100) {
+      barColor = '#F59E0B';
+    }
   }
+
+  const summaryText = [
+    `Белки ${protein.consumed}/${protein.target ?? '—'}г`,
+    `Жиры ${fat.consumed}/${fat.target ?? '—'}г`,
+    `Углеводы ${carbs.consumed}/${carbs.target ?? '—'}г`,
+    `Ккал ${calories.consumed}/${calories.target ?? '—'}`,
+  ].join(' • ');
 
   return (
     <View style={styles.container}>
-      <View style={styles.macroRow}>
-        {nutrients.map(n => (
-          <View key={n.label} style={styles.macroBlock}>
-            <Text style={styles.macroLabel}>{n.label}</Text>
-            <Text style={styles.macroValue}>
-              {n.consumed}/{n.target ?? '—'} g
-            </Text>
-          </View>
-        ))}
-      </View>
-      <View style={styles.caloriesRow}>
-        <Text style={styles.caloriesValue}>
-          {calories.consumed}/{calories.target ?? '—'} kcal
-        </Text>
-      </View>
+      <Text style={styles.summaryText}>{summaryText}</Text>
       <View style={styles.progressRow}>
         <View style={styles.progressBar}>
-          <View
-            style={[
-              styles.progressFill,
-              { width: `${barPercent}%`, backgroundColor: barColor },
-            ]}
-          />
+          {percent !== undefined && (
+            <View
+              style={[
+                styles.progressFill,
+                { width: `${barPercent}%`, backgroundColor: barColor },
+              ]}
+            />
+          )}
         </View>
-        <Text style={styles.percentage}>{rawPercent}%</Text>
+        <Text style={styles.percentage}>
+          {percent !== undefined ? `${percent}%` : '—'}
+        </Text>
       </View>
     </View>
   );
@@ -71,50 +64,31 @@ const MacronutrientSummary: React.FC<MacronutrientSummaryProps> = ({
 const styles = StyleSheet.create({
   container: {
     backgroundColor: '#1E1E1E',
-    padding: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
     borderRadius: 8,
     marginBottom: 16,
   },
-  macroRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 8,
-  },
-  macroBlock: {
-    flex: 1,
-    alignItems: 'center',
-  },
-  macroLabel: {
+  summaryText: {
     color: '#fff',
     fontSize: 12,
-    marginBottom: 4,
-  },
-  macroValue: {
-    color: '#fff',
-    fontWeight: 'bold',
-  },
-  caloriesRow: {
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  caloriesValue: {
-    color: '#fff',
-    fontWeight: 'bold',
+    textAlign: 'center',
   },
   progressRow: {
     flexDirection: 'row',
     alignItems: 'center',
+    marginTop: 4,
   },
   progressBar: {
     flex: 1,
-    height: 8,
+    height: 6,
     backgroundColor: '#323232',
-    borderRadius: 4,
+    borderRadius: 3,
     overflow: 'hidden',
   },
   progressFill: {
     height: '100%',
-    borderRadius: 4,
+    borderRadius: 3,
   },
   percentage: {
     color: '#fff',

--- a/MedTrackApp/src/components/MacronutrientSummary.tsx
+++ b/MedTrackApp/src/components/MacronutrientSummary.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export type MacroValue = {
+  consumed: number;
+  target?: number;
+};
+
+export type MacronutrientSummaryProps = {
+  calories: MacroValue;
+  protein: MacroValue;
+  fat: MacroValue;
+  carbs: MacroValue;
+};
+
+const MacronutrientSummary: React.FC<MacronutrientSummaryProps> = ({
+  calories,
+  protein,
+  fat,
+  carbs,
+}) => {
+  const nutrients = [
+    { label: 'Protein', ...protein },
+    { label: 'Fat', ...fat },
+    { label: 'Carbs', ...carbs },
+  ];
+
+  const rawPercent = calories.target
+    ? Math.round((calories.consumed / calories.target) * 100)
+    : 0;
+  const barPercent = Math.min(rawPercent, 100);
+  let barColor = '#22C55E';
+  if (rawPercent === 100) {
+    barColor = '#F59E0B';
+  } else if (rawPercent > 100) {
+    barColor = '#EF4444';
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.macroRow}>
+        {nutrients.map(n => (
+          <View key={n.label} style={styles.macroBlock}>
+            <Text style={styles.macroLabel}>{n.label}</Text>
+            <Text style={styles.macroValue}>
+              {n.consumed}/{n.target ?? '—'} g
+            </Text>
+          </View>
+        ))}
+      </View>
+      <View style={styles.caloriesRow}>
+        <Text style={styles.caloriesValue}>
+          {calories.consumed}/{calories.target ?? '—'} kcal
+        </Text>
+      </View>
+      <View style={styles.progressRow}>
+        <View style={styles.progressBar}>
+          <View
+            style={[
+              styles.progressFill,
+              { width: `${barPercent}%`, backgroundColor: barColor },
+            ]}
+          />
+        </View>
+        <Text style={styles.percentage}>{rawPercent}%</Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#1E1E1E',
+    padding: 10,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  macroRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  macroBlock: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  macroLabel: {
+    color: '#fff',
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  macroValue: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  caloriesRow: {
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  caloriesValue: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  progressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  progressBar: {
+    flex: 1,
+    height: 8,
+    backgroundColor: '#323232',
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 4,
+  },
+  percentage: {
+    color: '#fff',
+    marginLeft: 8,
+    fontSize: 12,
+  },
+});
+
+export default MacronutrientSummary;

--- a/MedTrackApp/src/components/index.ts
+++ b/MedTrackApp/src/components/index.ts
@@ -1,3 +1,4 @@
 export { default as AdherenceDisplay } from './AdherenceDisplay';
 export { default as CategorySummaryCard } from './CategorySummaryCard';
 export { default as NutritionCalendar } from './NutritionCalendar';
+export { default as MacronutrientSummary } from './MacronutrientSummary';

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -17,10 +17,11 @@ const DietScreen: React.FC = () => {
   ]);
 
   const mockMacros = {
-    calories: { consumed: 1200, target: 2000 },
-    protein: { consumed: 45, target: 120 },
-    fat: { consumed: 60, target: 70 },
-    carbs: { consumed: 150, target: 250 },
+    caloriesConsumed: 294,
+    caloriesTarget: 3300,
+    protein: 20.42,
+    fat: 21.43,
+    carbs: 3.46,
   };
 
   const getHasFoodByDate = (date: string) => mockFoodDates.has(date);
@@ -38,3 +39,4 @@ const DietScreen: React.FC = () => {
 };
 
 export default DietScreen;
+

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { format } from 'date-fns';
 
-import { NutritionCalendar } from '../../components';
+import { NutritionCalendar, MacronutrientSummary } from '../../components';
 import { styles } from './styles';
 
 const DietScreen: React.FC = () => {
@@ -16,6 +16,13 @@ const DietScreen: React.FC = () => {
     '2025-08-22',
   ]);
 
+  const mockMacros = {
+    calories: { consumed: 1200, target: 2000 },
+    protein: { consumed: 45, target: 120 },
+    fat: { consumed: 60, target: 70 },
+    carbs: { consumed: 150, target: 250 },
+  };
+
   const getHasFoodByDate = (date: string) => mockFoodDates.has(date);
 
   return (
@@ -25,6 +32,7 @@ const DietScreen: React.FC = () => {
         onChange={setSelectedDate}
         getHasFoodByDate={getHasFoodByDate}
       />
+      <MacronutrientSummary {...mockMacros} />
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
## Summary
- add component to summarize macros and calories with progress bar
- render macronutrient summary on Diet screen beneath weekly calendar

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a706b57bc0832f9736c60c6a4195f5