### PR TITLE
Add nutrition summary grid to Diet screen

### DIFF
--- a/MedTrackApp/src/components/NutritionSummary.tsx
+++ b/MedTrackApp/src/components/NutritionSummary.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export type Macro = {
+  consumed: number;
+  target: number;
+};
+
+export type Calories = {
+  consumed: number;
+  target?: number;
+};
+
+export type NutritionSummaryProps = {
+  protein: Macro;
+  fat: Macro;
+  carbs: Macro;
+  calories: Calories;
+};
+
+const NutritionSummary: React.FC<NutritionSummaryProps> = ({
+  protein,
+  fat,
+  carbs,
+  calories,
+}) => {
+  const percent = calories.target
+    ? Math.round((calories.consumed / calories.target) * 100)
+    : 0;
+
+  let barColor = '#22C55E';
+  if (percent === 100) {
+    barColor = '#F59E0B';
+  } else if (percent > 100) {
+    barColor = '#EF4444';
+  }
+
+  const barWidth = calories.target
+    ? `${Math.min(percent, 100)}%`
+    : '0%';
+
+  const calorieText = calories.target
+    ? `${calories.consumed}/${calories.target} kcal (${percent}%)`
+    : '—';
+
+  return (
+    <View style={styles.grid}>
+      <View style={[styles.cell, styles.borderRight, styles.borderBottom]}>
+        <Text style={styles.cellText}>
+          Protein → {protein.consumed}/{protein.target} g
+        </Text>
+      </View>
+      <View style={[styles.cell, styles.borderBottom]}>
+        <Text style={styles.cellText}>
+          Fat → {fat.consumed}/{fat.target} g
+        </Text>
+      </View>
+      <View style={[styles.cell, styles.borderRight]}>
+        <Text style={styles.cellText}>
+          Carbs → {carbs.consumed}/{carbs.target} g
+        </Text>
+      </View>
+      <View style={styles.cell}>
+        <Text style={styles.cellText}>Calories → {calorieText}</Text>
+        <View style={styles.progressBarBackground}>
+          {calories.target && (
+            <View
+              style={[styles.progressBarFill, { width: barWidth, backgroundColor: barColor }]}
+            />
+          )}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    borderWidth: 1,
+    borderColor: '#333',
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  cell: {
+    width: '50%',
+    padding: 10,
+  },
+  borderRight: {
+    borderRightWidth: 1,
+    borderColor: '#333',
+  },
+  borderBottom: {
+    borderBottomWidth: 1,
+    borderColor: '#333',
+  },
+  cellText: {
+    color: 'white',
+    fontSize: 14,
+  },
+  progressBarBackground: {
+    height: 6,
+    backgroundColor: '#333',
+    borderRadius: 3,
+    marginTop: 4,
+    overflow: 'hidden',
+  },
+  progressBarFill: {
+    height: 6,
+    borderRadius: 3,
+  },
+});
+
+export default NutritionSummary;
+

--- a/MedTrackApp/src/components/index.ts
+++ b/MedTrackApp/src/components/index.ts
@@ -1,3 +1,4 @@
 export { default as AdherenceDisplay } from './AdherenceDisplay';
 export { default as CategorySummaryCard } from './CategorySummaryCard';
 export { default as NutritionCalendar } from './NutritionCalendar';
+export { default as NutritionSummary } from './NutritionSummary';

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { format } from 'date-fns';
 
-import { NutritionCalendar } from '../../components';
+import { NutritionCalendar, NutritionSummary } from '../../components';
 import { styles } from './styles';
 
 const DietScreen: React.FC = () => {
@@ -18,6 +18,13 @@ const DietScreen: React.FC = () => {
 
   const getHasFoodByDate = (date: string) => mockFoodDates.has(date);
 
+  const summaryData = {
+    protein: { consumed: 45, target: 120 },
+    fat: { consumed: 60, target: 70 },
+    carbs: { consumed: 150, target: 250 },
+    calories: { consumed: 1200, target: 2000 },
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <NutritionCalendar
@@ -25,6 +32,7 @@ const DietScreen: React.FC = () => {
         onChange={setSelectedDate}
         getHasFoodByDate={getHasFoodByDate}
       />
+      <NutritionSummary {...summaryData} />
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
## Summary
- add NutritionSummary component rendering a 2x2 grid of macros and calories
- show calorie progress bar with color change once targets met or exceeded
- integrate summary grid on Diet screen below weekly calendar

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a71cb09bc8832fb7adb6455c423f3a