### PR TITLE
feat: add nutrition summary to diet screen

### DIFF
--- a/MedTrackApp/__tests__/NutritionSummary.test.tsx
+++ b/MedTrackApp/__tests__/NutritionSummary.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { NutritionSummary } from '../src/components';
+
+describe('NutritionSummary', () => {
+  it('displays correct calorie percentage', async () => {
+    let component: renderer.ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(
+        <NutritionSummary
+          proteinConsumed={45}
+          proteinTarget={120}
+          fatConsumed={60}
+          fatTarget={70}
+          carbsConsumed={150}
+          carbsTarget={250}
+          caloriesConsumed={1200}
+          caloriesTarget={2000}
+        />,
+      );
+    });
+    const percent = component.root.findByProps({ testID: 'calorie-percent' })
+      .props.children;
+    expect(percent).toBe('60%');
+  });
+
+  it('shows placeholder when calorie target missing', async () => {
+    let component: renderer.ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(
+        <NutritionSummary
+          proteinConsumed={10}
+          proteinTarget={20}
+          fatConsumed={5}
+          fatTarget={10}
+          carbsConsumed={15}
+          carbsTarget={30}
+          caloriesConsumed={500}
+        />,
+      );
+    });
+    const percent = component.root.findByProps({ testID: 'calorie-percent' })
+      .props.children;
+    expect(percent).toBe('—');
+  });
+});
+

--- a/MedTrackApp/src/components/NutritionSummary.tsx
+++ b/MedTrackApp/src/components/NutritionSummary.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export type NutritionSummaryProps = {
+  proteinConsumed?: number;
+  proteinTarget?: number;
+  fatConsumed?: number;
+  fatTarget?: number;
+  carbsConsumed?: number;
+  carbsTarget?: number;
+  caloriesConsumed?: number;
+  caloriesTarget?: number;
+};
+
+const NutritionSummary: React.FC<NutritionSummaryProps> = ({
+  proteinConsumed,
+  proteinTarget,
+  fatConsumed,
+  fatTarget,
+  carbsConsumed,
+  carbsTarget,
+  caloriesConsumed,
+  caloriesTarget,
+}) => {
+  const formatMetric = (
+    consumed?: number,
+    target?: number,
+    unit: string = 'г',
+  ) => {
+    const c = consumed ?? '—';
+    const t = target != null ? `${target}${unit}` : '—';
+    return `${c}/${t}`;
+  };
+
+  const targetDefined = caloriesTarget != null && caloriesTarget > 0;
+  const percent =
+    targetDefined && caloriesConsumed != null
+      ? (caloriesConsumed / caloriesTarget) * 100
+      : 0;
+  const percentText = targetDefined ? `${Math.round(percent)}%` : '—';
+
+  let barColor = '#22C55E';
+  if (percent > 120) barColor = '#EF4444';
+  else if (percent > 100) barColor = '#F59E0B';
+
+  const progressWidth = targetDefined ? Math.min(percent, 100) : 0;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.rowText}>
+        {`Белки ${formatMetric(proteinConsumed, proteinTarget)} • Жиры ${formatMetric(fatConsumed, fatTarget)} • Углеводы ${formatMetric(carbsConsumed, carbsTarget)} • Ккал ${formatMetric(caloriesConsumed, caloriesTarget, '')}`}
+      </Text>
+      <View style={styles.progressWrapper}>
+        <View style={styles.progressBar}>
+          <View
+            style={[
+              styles.progressFill,
+              { width: `${progressWidth}%`, backgroundColor: barColor },
+            ]}
+          />
+        </View>
+        <Text testID="calorie-percent" style={styles.percentText}>
+          {percentText}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    marginTop: 8,
+  },
+  rowText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+  },
+  progressWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  progressBar: {
+    flex: 1,
+    height: 8,
+    backgroundColor: '#2C2C2C',
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+  },
+  percentText: {
+    marginLeft: 8,
+    color: '#FFFFFF',
+    fontSize: 12,
+  },
+});
+
+export default NutritionSummary;
+

--- a/MedTrackApp/src/components/index.ts
+++ b/MedTrackApp/src/components/index.ts
@@ -1,3 +1,4 @@
 export { default as AdherenceDisplay } from './AdherenceDisplay';
 export { default as CategorySummaryCard } from './CategorySummaryCard';
 export { default as NutritionCalendar } from './NutritionCalendar';
+export { default as NutritionSummary } from './NutritionSummary';

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { format } from 'date-fns';
 
-import { NutritionCalendar } from '../../components';
+import { NutritionCalendar, NutritionSummary } from '../../components';
 import { styles } from './styles';
 
 const DietScreen: React.FC = () => {
@@ -24,6 +24,16 @@ const DietScreen: React.FC = () => {
         value={selectedDate}
         onChange={setSelectedDate}
         getHasFoodByDate={getHasFoodByDate}
+      />
+      <NutritionSummary
+        proteinConsumed={45}
+        proteinTarget={120}
+        fatConsumed={60}
+        fatTarget={70}
+        carbsConsumed={150}
+        carbsTarget={250}
+        caloriesConsumed={1200}
+        caloriesTarget={2000}
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary
- add compact macronutrient summary component with calorie progress bar
- render nutrition summary below calendar on diet screen
- test calorie percentage calculations and placeholder behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74cbfe504832f8d1ec450d7a51161