### PR TITLE
feat: add expandable meal panels

### DIFF
--- a/MedTrackApp/src/components/MealPanel.tsx
+++ b/MedTrackApp/src/components/MealPanel.tsx
@@ -1,0 +1,270 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+export type MealEntry = {
+  id: string;
+  name: string;
+  amount?: string;
+  calories: number;
+  fat: number;
+  carbs: number;
+  protein: number;
+};
+
+export type MealPanelProps = {
+  icon: string;
+  title: string;
+  totalCalories: number;
+  fat: number;
+  carbs: number;
+  protein: number;
+  rskPercent?: number;
+  entries: MealEntry[];
+  onAdd?: () => void;
+  onSelectEntry?: (id: string) => void;
+  onCopyFromYesterday?: () => void;
+  onSaveMeal?: () => void;
+  onCamera?: () => void;
+};
+
+const formatNumber = (value: number) =>
+  value.toLocaleString('ru-RU', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+
+const MealPanel: React.FC<MealPanelProps> = ({
+  icon,
+  title,
+  totalCalories,
+  fat,
+  carbs,
+  protein,
+  rskPercent,
+  entries,
+  onAdd,
+  onSelectEntry,
+  onCopyFromYesterday,
+  onSaveMeal,
+  onCamera,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const toggle = () => setExpanded(prev => !prev);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerRow}>
+        <TouchableOpacity style={styles.headerMain} onPress={toggle} activeOpacity={0.7}>
+          <Text style={styles.icon}>{icon}</Text>
+          <Text style={styles.title}>{title}</Text>
+          <View style={styles.calorieBlock}>
+            <Text style={styles.calories}>{formatNumber(totalCalories)}</Text>
+            <Text style={styles.caloriesLabel}>Калории</Text>
+          </View>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.addButton}
+          onPress={onAdd}
+          activeOpacity={0.7}
+          accessibilityLabel={`Добавить запись в раздел ${title}`}
+        >
+          <Icon name="plus" size={24} color="#22C55E" />
+        </TouchableOpacity>
+      </View>
+      <View style={styles.divider} />
+      <TouchableOpacity style={styles.metricsRow} onPress={toggle} activeOpacity={0.7}>
+        <View style={styles.metrics}>
+          <Text style={styles.metric}>{formatNumber(fat)}</Text>
+          <Text style={styles.metric}>{formatNumber(carbs)}</Text>
+          <Text style={styles.metric}>{formatNumber(protein)}</Text>
+          <Text style={styles.metric}>
+            {rskPercent !== undefined ? `${rskPercent}%` : '—'}
+          </Text>
+        </View>
+        <Icon
+          name={expanded ? 'chevron-up' : 'chevron-down'}
+          size={20}
+          color="#fff"
+        />
+      </TouchableOpacity>
+      {expanded && (
+        <>
+          <View style={styles.entries}>
+            {entries.length === 0 ? (
+              <View style={styles.placeholderRow}>
+                <Text style={styles.placeholderText}>Записей пока нет</Text>
+              </View>
+            ) : (
+              entries.map(entry => (
+                <TouchableOpacity
+                  key={entry.id}
+                  style={styles.entryRow}
+                  onPress={() => onSelectEntry && onSelectEntry(entry.id)}
+                >
+                  <View style={{ flex: 1 }}>
+                    <View style={styles.entryHeader}>
+                      <Text style={styles.entryName}>{entry.name}</Text>
+                      <Text style={styles.entryCalories}>
+                        {formatNumber(entry.calories)}
+                      </Text>
+                    </View>
+                    {entry.amount && (
+                      <Text style={styles.entryAmount}>{entry.amount}</Text>
+                    )}
+                    <Text style={styles.entryMetrics}>
+                      {formatNumber(entry.fat)} • {formatNumber(entry.carbs)} • {formatNumber(entry.protein)}
+                    </Text>
+                  </View>
+                  <Icon name="chevron-right" size={20} color="#fff" />
+                </TouchableOpacity>
+              ))
+            )}
+          </View>
+          <View style={styles.actionBar}>
+            <TouchableOpacity
+              style={styles.action}
+              onPress={onCopyFromYesterday}
+            >
+              <Icon name="content-copy" size={16} color="#22C55E" />
+              <Text style={styles.actionText}>Копировать из вчера</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.action} onPress={onSaveMeal}>
+              <Icon name="bookmark-plus-outline" size={16} color="#22C55E" />
+              <Text style={styles.actionText}>Сохранить Еду</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.action} onPress={onCamera}>
+              <Icon name="camera" size={16} color="#22C55E" />
+              <Text style={styles.actionText}>Камера</Text>
+            </TouchableOpacity>
+          </View>
+        </>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#1E1E1E',
+    borderRadius: 16,
+    marginHorizontal: 8,
+    marginBottom: 12,
+    padding: 12,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  headerMain: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  icon: {
+    fontSize: 20,
+    marginRight: 8,
+  },
+  title: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
+    flex: 1,
+  },
+  calorieBlock: {
+    alignItems: 'flex-end',
+    marginRight: 8,
+  },
+  calories: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  caloriesLabel: {
+    color: 'rgba(255,255,255,0.6)',
+    fontSize: 12,
+  },
+  addButton: {
+    width: 40,
+    height: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  divider: {
+    height: 1,
+    backgroundColor: '#323232',
+    marginVertical: 10,
+  },
+  metricsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  metrics: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  metric: {
+    flex: 1,
+    color: '#fff',
+    textAlign: 'center',
+  },
+  entries: {
+    marginTop: 10,
+  },
+  entryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#323232',
+  },
+  entryHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  entryName: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  entryCalories: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  entryAmount: {
+    color: '#22C55E',
+    fontSize: 12,
+  },
+  entryMetrics: {
+    color: 'rgba(255,255,255,0.6)',
+    fontSize: 12,
+  },
+  placeholderRow: {
+    paddingVertical: 8,
+  },
+  placeholderText: {
+    color: 'rgba(255,255,255,0.6)',
+    textAlign: 'center',
+    fontSize: 14,
+  },
+  actionBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    paddingVertical: 8,
+    borderTopWidth: 1,
+    borderTopColor: '#323232',
+  },
+  action: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  actionText: {
+    color: '#22C55E',
+    fontSize: 12,
+    marginLeft: 4,
+  },
+});
+
+export default MealPanel;

--- a/MedTrackApp/src/components/index.ts
+++ b/MedTrackApp/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as AdherenceDisplay } from './AdherenceDisplay';
 export { default as CategorySummaryCard } from './CategorySummaryCard';
 export { default as NutritionCalendar } from './NutritionCalendar';
 export { default as MacronutrientSummary } from './MacronutrientSummary';
+export { default as MealPanel } from './MealPanel';

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -1,8 +1,13 @@
 import React, { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { ScrollView } from 'react-native';
 import { format } from 'date-fns';
 
-import { NutritionCalendar, MacronutrientSummary } from '../../components';
+import {
+  NutritionCalendar,
+  MacronutrientSummary,
+  MealPanel,
+} from '../../components';
 import { styles } from './styles';
 
 const DietScreen: React.FC = () => {
@@ -24,16 +29,82 @@ const DietScreen: React.FC = () => {
     carbs: 3.46,
   };
 
+  const dayPercent = mockMacros.caloriesTarget
+    ? Math.round((mockMacros.caloriesConsumed / mockMacros.caloriesTarget) * 100)
+    : undefined;
+
+  const meals = [
+    {
+      key: 'breakfast',
+      title: 'Завтрак',
+      icon: '🌅',
+      totalCalories: 294,
+      fat: 21.43,
+      carbs: 3.46,
+      protein: 20.42,
+      rskPercent: dayPercent,
+      entries: [
+        {
+          id: '1',
+          name: 'Омлет или Яичница',
+          amount: '3 яйца',
+          calories: 294,
+          fat: 21.43,
+          carbs: 3.46,
+          protein: 20.42,
+        },
+      ],
+    },
+    {
+      key: 'lunch',
+      title: 'Обед',
+      icon: '☀️',
+      totalCalories: 0,
+      fat: 0,
+      carbs: 0,
+      protein: 0,
+      rskPercent: dayPercent,
+      entries: [],
+    },
+    {
+      key: 'dinner',
+      title: 'Ужин',
+      icon: '🌇',
+      totalCalories: 0,
+      fat: 0,
+      carbs: 0,
+      protein: 0,
+      rskPercent: dayPercent,
+      entries: [],
+    },
+    {
+      key: 'snack',
+      title: 'Перекус/Другое',
+      icon: '🌙',
+      totalCalories: 0,
+      fat: 0,
+      carbs: 0,
+      protein: 0,
+      rskPercent: dayPercent,
+      entries: [],
+    },
+  ];
+
   const getHasFoodByDate = (date: string) => mockFoodDates.has(date);
 
   return (
     <SafeAreaView style={styles.container}>
-      <NutritionCalendar
-        value={selectedDate}
-        onChange={setSelectedDate}
-        getHasFoodByDate={getHasFoodByDate}
-      />
-      <MacronutrientSummary {...mockMacros} />
+      <ScrollView contentContainerStyle={styles.content}>
+        <NutritionCalendar
+          value={selectedDate}
+          onChange={setSelectedDate}
+          getHasFoodByDate={getHasFoodByDate}
+        />
+        <MacronutrientSummary {...mockMacros} />
+        {meals.map(meal => (
+          <MealPanel key={meal.key} {...meal} />
+        ))}
+      </ScrollView>
     </SafeAreaView>
   );
 };

--- a/MedTrackApp/src/screens/DietScreen/styles.ts
+++ b/MedTrackApp/src/screens/DietScreen/styles.ts
@@ -6,4 +6,7 @@ export const styles = StyleSheet.create({
     backgroundColor: '#121212',
     paddingTop: Platform.OS === 'ios' ? 10 : StatusBar.currentHeight,
   },
+  content: {
+    padding: 16,
+  },
 });


### PR DESCRIPTION
## Summary
- add reusable MealPanel component with header, metrics strip and actions
- show four meal panels on diet screen below calendar and macros summary
- enable scrolling container for nutrition screen content

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a75348e5ec832f890cf907e160ab45