### PR TITLE
Add long-press menu to NutritionCalendar

### DIFF
--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { ScrollView } from 'react-native';
+import { ScrollView, Platform, ToastAndroid, Alert } from 'react-native';
 import { format } from 'date-fns';
 
 import {
@@ -92,6 +92,22 @@ const DietScreen: React.FC = () => {
 
   const getHasFoodByDate = (date: string) => mockFoodDates.has(date);
 
+  const showToast = (message: string) => {
+    if (Platform.OS === 'android') {
+      ToastAndroid.show(message, ToastAndroid.SHORT);
+    } else {
+      Alert.alert(message);
+    }
+  };
+
+  const handleCopyFromYesterday = (date: string) => {
+    showToast(`Скопировано из вчера для ${date}`);
+  };
+
+  const handleClearDay = (date: string) => {
+    showToast(`День ${date} очищен`);
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView contentContainerStyle={styles.content}>
@@ -99,6 +115,8 @@ const DietScreen: React.FC = () => {
           value={selectedDate}
           onChange={setSelectedDate}
           getHasFoodByDate={getHasFoodByDate}
+          onCopyFromYesterday={handleCopyFromYesterday}
+          onClearDay={handleClearDay}
         />
         <MacronutrientSummary {...mockMacros} />
         {meals.map(({ key, ...meal }) => (


### PR DESCRIPTION
## Summary
- add copy/clear day long-press menu to NutritionCalendar
- expose callbacks for copying and clearing meals
- show toasts from DietScreen when actions run

## Testing
- `npm test` *(fails: Exceeded timeout of 5000 ms for a test in __tests__/AccountScreen.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a8444e2904832f8d0ee1c53e378493