### PR TITLE
feat: add day actions to nutrition calendar

### DIFF
--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { ScrollView } from 'react-native';
+import {
+  ScrollView,
+  Alert,
+  ToastAndroid,
+  Platform,
+} from 'react-native';
 import { format } from 'date-fns';
 
 import {
@@ -92,6 +97,24 @@ const DietScreen: React.FC = () => {
 
   const getHasFoodByDate = (date: string) => mockFoodDates.has(date);
 
+  const showToast = (message: string) => {
+    if (Platform.OS === 'android') {
+      ToastAndroid.show(message, ToastAndroid.SHORT);
+    } else {
+      Alert.alert(message);
+    }
+  };
+
+  const handleCopyFromYesterday = (date: string) => {
+    // Stub implementation
+    showToast('Рацион скопирован из вчера');
+  };
+
+  const handleClearDay = (date: string) => {
+    // Stub implementation
+    showToast('День очищен');
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView contentContainerStyle={styles.content}>
@@ -99,6 +122,8 @@ const DietScreen: React.FC = () => {
           value={selectedDate}
           onChange={setSelectedDate}
           getHasFoodByDate={getHasFoodByDate}
+          onCopyFromYesterday={handleCopyFromYesterday}
+          onClearDay={handleClearDay}
         />
         <MacronutrientSummary {...mockMacros} />
         {meals.map(({ key, ...meal }) => (


### PR DESCRIPTION
## Summary
- enable long-press on calendar days to show copy/clear actions
- extend nutrition calendar API with copy and clear callbacks
- demo stub callbacks with toasts in DietScreen

## Testing
- `npm test` *(fails: persists avatar after selection exceeded timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a8449a83a0832faee6ffed1f8ac0a0