### PR TITLE
Fix RSK rounding and display

### DIFF
--- a/MedTrackApp/src/components/MacronutrientSummary.tsx
+++ b/MedTrackApp/src/components/MacronutrientSummary.tsx
@@ -4,7 +4,7 @@ import { formatNumber } from '../utils/number';
 
 export type MacronutrientSummaryProps = {
   caloriesConsumed: number;
-  caloriesTarget?: number;
+  rskPercent?: number;
   protein: number;
   fat: number;
   carbs: number;
@@ -12,14 +12,12 @@ export type MacronutrientSummaryProps = {
 
 const MacronutrientSummary: React.FC<MacronutrientSummaryProps> = ({
   caloriesConsumed,
-  caloriesTarget,
+  rskPercent,
   protein,
   fat,
   carbs,
 }) => {
-  const percent = caloriesTarget
-    ? Math.round((caloriesConsumed / caloriesTarget) * 100)
-    : undefined;
+  const percent = rskPercent;
   const barPercent = percent !== undefined ? Math.min(percent, 100) : 0;
 
   let barColor = '#22C55E';

--- a/MedTrackApp/src/nutrition/aggregate.ts
+++ b/MedTrackApp/src/nutrition/aggregate.ts
@@ -60,3 +60,47 @@ export const computeMealRsk = (
   return (mealCal / targetCal) * 100;
 };
 
+export const computeRskPercents = (
+  mealCal: Record<MealType, number>,
+  targetCal?: number | null,
+): { day: number; byMeal: Record<MealType, number> } | null => {
+  if (!targetCal || targetCal <= 0) return null;
+
+  const keys: MealType[] = ['breakfast', 'lunch', 'dinner', 'snack'];
+  const dayCal = keys.reduce((sum, k) => sum + mealCal[k], 0);
+
+  const clamp = (n: number) => Math.max(0, Math.min(100, n));
+
+  const dayPctShown = clamp(Math.round((dayCal / targetCal) * 100));
+
+  let lastNonEmpty: MealType | null = null;
+  keys.forEach(k => {
+    if (mealCal[k] > 0) {
+      lastNonEmpty = k;
+    }
+  });
+
+  const result: Record<MealType, number> = {
+    breakfast: 0,
+    lunch: 0,
+    dinner: 0,
+    snack: 0,
+  };
+
+  if (lastNonEmpty === null) {
+    return { day: dayPctShown, byMeal: result };
+  }
+
+  let sumOthers = 0;
+  keys.forEach(k => {
+    if (mealCal[k] === 0 || k === lastNonEmpty) return;
+    const pct = clamp(Math.round((mealCal[k] / targetCal) * 100));
+    result[k] = pct;
+    sumOthers += pct;
+  });
+
+  result[lastNonEmpty] = clamp(Math.max(0, dayPctShown - sumOthers));
+
+  return { day: dayPctShown, byMeal: result };
+};
+


### PR DESCRIPTION
## Summary
- ensure meal RSK percentages sum to daily total and assign rounding remainder to last non-empty meal
- show daily RSK percent via new computeRskPercents utility and pass to summary component
- clean up UI to display "—" when target calories missing
- add tests for RSK rounding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acbca73e08832fa01df7196b4b59aa