### PR TITLE
Always show favorite toggle in food details

### DIFF
--- a/MedTrackApp/src/nutrition/storage.ts
+++ b/MedTrackApp/src/nutrition/storage.ts
@@ -14,10 +14,13 @@ export async function loadFavorites(): Promise<FavoriteItem[]> {
   }
 }
 
-export async function saveFavorites(items: FavoriteItem[]) {
+export async function saveFavorites(items: FavoriteItem[]): Promise<boolean> {
   try {
     await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(items));
-  } catch (e) {}
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 export async function loadRecents(): Promise<RecentItem[]> {


### PR DESCRIPTION
## Summary
- keep "В избранное" control visible in Add Food details and sync with list stars
- handle favorite toggling errors

## Testing
- `npm test` *(fails: __tests__/AccountScreen.test.tsx - Exceeded timeout)*
- `npm run lint` *(fails: 4 errors, 96 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ad72948b2c832fb70e3643ddbf5e5b