### PR TITLE
Добавить санитайзер и ограничения ввода в модальное окно еды

### DIFF
--- a/MedTrackApp/src/utils/sanitize.ts
+++ b/MedTrackApp/src/utils/sanitize.ts
@@ -1,0 +1,10 @@
+export const sanitizeText = (value: string, maxLength: number) =>
+  value.replace(/\s+/g, ' ').trim().slice(0, maxLength);
+
+export const sanitizeNumber = (value: string, maxLength: number, decimals = 3) => {
+  const sanitized = value.replace(/[^0-9.,]/g, '').replace(',', '.');
+  const [intPart, fracPart = ''] = sanitized.split('.');
+  const trimmedInt = intPart.slice(0, maxLength);
+  const trimmedFrac = fracPart.slice(0, decimals);
+  return trimmedFrac.length > 0 ? `${trimmedInt}.${trimmedFrac}` : trimmedInt;
+};


### PR DESCRIPTION
## Summary
- limit and sanitize text/number fields in add/edit food modal
- add shared sanitizer utilities
- show "★ В избранное" toggle with multiline note fields

## Testing
- `npm test`
- `npm run lint` *(fails: React hook dependencies in DietScreen.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7e0c07d4832fa9092245306b2625