### PR TITLE
feat: add food edit screen

### DIFF
--- a/MedTrackApp/src/navigation/AppNavigator.tsx
+++ b/MedTrackApp/src/navigation/AppNavigator.tsx
@@ -14,6 +14,7 @@ import Medications from '../screens/Medications';
 import BodyDiaryScreen from '../screens/BodyDiaryScreen';
 import DietScreen from '../screens/DietScreen';
 import TrainingScreen from '../screens/TrainingScreen';
+import FoodEditScreen from '../screens/FoodEditScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator();
@@ -42,6 +43,13 @@ const ProfileStack = () => (
   </Stack.Navigator>
 );
 
+const DietStack = () => (
+  <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Screen name="Diet" component={DietScreen} />
+    <Stack.Screen name="FoodEdit" component={FoodEditScreen} />
+  </Stack.Navigator>
+);
+
 const AppNavigator: React.FC = () => {
   return (
     <NavigationContainer>
@@ -58,7 +66,7 @@ const AppNavigator: React.FC = () => {
         />
         <Tab.Screen
           name="Питание"
-          component={DietScreen}
+          component={DietStack}
           options={{ tabBarIcon: ({ color }) => <Icon name="food-apple" size={30} color={color} /> }}
         />
         <Tab.Screen

--- a/MedTrackApp/src/navigation/types.ts
+++ b/MedTrackApp/src/navigation/types.ts
@@ -1,4 +1,5 @@
 import { Reminder } from '../types';
+import { NormalizedEntry } from '../nutrition/types';
 
 export type RootStackParamList = {
   MainScreen: undefined;
@@ -23,4 +24,6 @@ export type RootStackParamList = {
   Profile: undefined;
   Medications: undefined;
   BodyDiary: undefined;
+  Diet: undefined;
+  FoodEdit: { entry: NormalizedEntry; onSave: (entry: NormalizedEntry) => void };
 };

--- a/MedTrackApp/src/navigation/types.ts
+++ b/MedTrackApp/src/navigation/types.ts
@@ -25,5 +25,8 @@ export type RootStackParamList = {
   Medications: undefined;
   BodyDiary: undefined;
   Diet: undefined;
-  FoodEdit: { entry: NormalizedEntry; onSave: (entry: NormalizedEntry) => void };
+  FoodEdit: {
+    entry: NormalizedEntry;
+    onSave: (entry: NormalizedEntry | null) => void;
+  };
 };

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -138,6 +138,11 @@ const DietScreen: React.FC = () => {
       onSave: updated => {
         setEntriesByDate(prev => {
           const day = prev[selectedDate] || createEmptyDay();
+          if (!updated) {
+            const mealArr = day[entry.mealType].filter(e => e.id !== entry.id);
+            const updatedDay = { ...day, [entry.mealType]: mealArr };
+            return { ...prev, [selectedDate]: updatedDay };
+          }
           const mealArr = day[updated.mealType].map(e =>
             e.id === updated.id ? updated : e,
           );

--- a/MedTrackApp/src/screens/FoodEditScreen/FoodEditScreen.tsx
+++ b/MedTrackApp/src/screens/FoodEditScreen/FoodEditScreen.tsx
@@ -8,6 +8,7 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { RootStackParamList } from '../../navigation';
 import { NormalizedEntry, FavoriteItem } from '../../nutrition/types';
 import { loadFavorites, saveFavorites } from '../../nutrition/storage';
+import { formatNumber } from '../../utils/number';
 import { styles } from './styles';
 
 export type FoodEditRouteProp = RouteProp<RootStackParamList, 'FoodEdit'>;
@@ -83,6 +84,22 @@ const FoodEditScreen: React.FC = () => {
     navigation.goBack();
   };
 
+  const handleDelete = () => {
+    onSave(null);
+    navigation.goBack();
+  };
+
+  const portionNum = parseFloat(portion.replace(',', '.'));
+  const factor =
+    entry.portionGrams && !isNaN(portionNum) && portionNum > 0
+      ? portionNum / entry.portionGrams
+      : 1;
+  const currentCalories = entry.calories * factor;
+  const currentFat = entry.fat * factor;
+  const currentCarbs = entry.carbs * factor;
+  const currentProtein = entry.protein * factor;
+  const percent = entry.portionGrams ? Math.round(factor * 100) : 100;
+
   return (
     <SafeAreaView style={styles.container}>
       <Text style={styles.title}>{entry.name}</Text>
@@ -100,7 +117,40 @@ const FoodEditScreen: React.FC = () => {
         onChangeText={setNote}
         placeholder="Заметка"
         placeholderTextColor="rgba(255,255,255,0.6)"
+        multiline
+        numberOfLines={3}
+        maxLength={200}
       />
+      <View style={styles.macroPanel}>
+        <View style={styles.macroRow}>
+          <View style={styles.macroBox}>
+            <Text style={styles.macroLabel}>Калории ({percent}%)</Text>
+            <Text style={styles.macroValue}>
+              {formatNumber(currentCalories, 0)}
+            </Text>
+          </View>
+          <View style={styles.macroBox}>
+            <Text style={styles.macroLabel}>Жир</Text>
+            <Text style={styles.macroValue}>
+              {formatNumber(currentFat, 1)}
+            </Text>
+          </View>
+        </View>
+        <View style={styles.macroRow}>
+          <View style={styles.macroBox}>
+            <Text style={styles.macroLabel}>Углев</Text>
+            <Text style={styles.macroValue}>
+              {formatNumber(currentCarbs, 1)}
+            </Text>
+          </View>
+          <View style={styles.macroBox}>
+            <Text style={styles.macroLabel}>Белок</Text>
+            <Text style={styles.macroValue}>
+              {formatNumber(currentProtein, 1)}
+            </Text>
+          </View>
+        </View>
+      </View>
       <View style={styles.actions}>
         <TouchableOpacity onPress={toggleFavorite} style={styles.favorite}>
           <Icon
@@ -109,9 +159,14 @@ const FoodEditScreen: React.FC = () => {
             color="#FFD700"
           />
         </TouchableOpacity>
-        <TouchableOpacity onPress={handleSave} style={styles.saveButton}>
-          <Text style={styles.saveText}>Сохранить</Text>
-        </TouchableOpacity>
+        <View style={styles.actionButtons}>
+          <TouchableOpacity onPress={handleDelete} style={styles.deleteButton}>
+            <Text style={styles.deleteText}>Удалить</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={handleSave} style={styles.saveButton}>
+            <Text style={styles.saveText}>Сохранить</Text>
+          </TouchableOpacity>
+        </View>
       </View>
     </SafeAreaView>
   );

--- a/MedTrackApp/src/screens/FoodEditScreen/FoodEditScreen.tsx
+++ b/MedTrackApp/src/screens/FoodEditScreen/FoodEditScreen.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+import { RootStackParamList } from '../../navigation';
+import { NormalizedEntry, FavoriteItem } from '../../nutrition/types';
+import { loadFavorites, saveFavorites } from '../../nutrition/storage';
+import { styles } from './styles';
+
+export type FoodEditRouteProp = RouteProp<RootStackParamList, 'FoodEdit'>;
+export type FoodEditNavProp = StackNavigationProp<RootStackParamList, 'FoodEdit'>;
+
+const FoodEditScreen: React.FC = () => {
+  const navigation = useNavigation<FoodEditNavProp>();
+  const { params } = useRoute<FoodEditRouteProp>();
+  const { entry, onSave } = params;
+
+  const [portion, setPortion] = useState(
+    entry.portionGrams ? String(entry.portionGrams) : '',
+  );
+  const [note, setNote] = useState(entry.note || '');
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+
+  const favKey = entry.sourceRefId || entry.id;
+  const isFavorite = favorites.some(f => f.sourceId === favKey);
+
+  useEffect(() => {
+    loadFavorites().then(setFavorites);
+  }, []);
+
+  const toggleFavorite = async () => {
+    if (isFavorite) {
+      const updated = favorites.filter(f => f.sourceId !== favKey);
+      setFavorites(updated);
+      const ok = await saveFavorites(updated);
+      if (!ok) setFavorites(favorites);
+    } else {
+      const factor = entry.portionGrams ? 100 / entry.portionGrams : undefined;
+      const per100g =
+        factor !== undefined
+          ? {
+              calories: entry.calories * factor,
+              protein: entry.protein * factor,
+              fat: entry.fat * factor,
+              carbs: entry.carbs * factor,
+            }
+          : undefined;
+      const newFav: FavoriteItem = {
+        id: Math.random().toString(),
+        sourceId: favKey,
+        name: entry.name || '',
+        defaultPortionGrams: entry.portionGrams,
+        per100g,
+        createdAt: Date.now(),
+      };
+      const updated = [newFav, ...favorites];
+      setFavorites(updated);
+      const ok = await saveFavorites(updated);
+      if (!ok) setFavorites(favorites);
+    }
+  };
+
+  const handleSave = () => {
+    const p = parseFloat(portion.replace(',', '.'));
+    if (!entry.portionGrams || isNaN(p) || p <= 0) {
+      navigation.goBack();
+      return;
+    }
+    const factor = p / entry.portionGrams;
+    const updated: NormalizedEntry = {
+      ...entry,
+      portionGrams: p,
+      calories: entry.calories * factor,
+      protein: entry.protein * factor,
+      fat: entry.fat * factor,
+      carbs: entry.carbs * factor,
+      note: note || undefined,
+    };
+    onSave(updated);
+    navigation.goBack();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>{entry.name}</Text>
+      <TextInput
+        style={styles.input}
+        keyboardType="numeric"
+        value={portion}
+        onChangeText={setPortion}
+        placeholder="Граммы"
+        placeholderTextColor="rgba(255,255,255,0.6)"
+      />
+      <TextInput
+        style={[styles.input, styles.note]}
+        value={note}
+        onChangeText={setNote}
+        placeholder="Заметка"
+        placeholderTextColor="rgba(255,255,255,0.6)"
+      />
+      <View style={styles.actions}>
+        <TouchableOpacity onPress={toggleFavorite} style={styles.favorite}>
+          <Icon
+            name={isFavorite ? 'star' : 'star-outline'}
+            size={24}
+            color="#FFD700"
+          />
+        </TouchableOpacity>
+        <TouchableOpacity onPress={handleSave} style={styles.saveButton}>
+          <Text style={styles.saveText}>Сохранить</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default FoodEditScreen;

--- a/MedTrackApp/src/screens/FoodEditScreen/index.ts
+++ b/MedTrackApp/src/screens/FoodEditScreen/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FoodEditScreen';

--- a/MedTrackApp/src/screens/FoodEditScreen/styles.ts
+++ b/MedTrackApp/src/screens/FoodEditScreen/styles.ts
@@ -21,16 +21,33 @@ export const styles = StyleSheet.create({
     marginBottom: 12,
   },
   note: {
-    height: 80,
+    minHeight: 60,
+    maxHeight: 72,
     textAlignVertical: 'top',
   },
   actions: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
   },
   favorite: {
     padding: 8,
+  },
+  actionButtons: {
+    flexDirection: 'row',
+    marginLeft: 'auto',
+    alignItems: 'center',
+  },
+  deleteButton: {
+    backgroundColor: '#EF4444',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    marginRight: 8,
+  },
+  deleteText: {
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: 16,
   },
   saveButton: {
     backgroundColor: '#22C55E',
@@ -42,5 +59,29 @@ export const styles = StyleSheet.create({
     color: '#fff',
     fontWeight: 'bold',
     fontSize: 16,
+  },
+  macroPanel: {
+    marginBottom: 16,
+  },
+  macroRow: {
+    flexDirection: 'row',
+  },
+  macroBox: {
+    flex: 1,
+    backgroundColor: '#1E1E1E',
+    margin: 4,
+    borderRadius: 8,
+    padding: 8,
+    alignItems: 'center',
+  },
+  macroLabel: {
+    color: 'rgba(255,255,255,0.6)',
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  macroValue: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: 'bold',
   },
 });

--- a/MedTrackApp/src/screens/FoodEditScreen/styles.ts
+++ b/MedTrackApp/src/screens/FoodEditScreen/styles.ts
@@ -1,0 +1,46 @@
+import { StyleSheet, Platform, StatusBar } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#121212',
+    padding: 16,
+    paddingTop: Platform.OS === 'ios' ? 10 : StatusBar.currentHeight,
+  },
+  title: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  input: {
+    backgroundColor: '#1E1E1E',
+    borderRadius: 8,
+    padding: 10,
+    color: '#fff',
+    marginBottom: 12,
+  },
+  note: {
+    height: 80,
+    textAlignVertical: 'top',
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  favorite: {
+    padding: 8,
+  },
+  saveButton: {
+    backgroundColor: '#22C55E',
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  saveText: {
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- allow editing meal entries via new FoodEdit screen
- keep Diet area in its own stack and hook up FoodEdit route
- enable updating grams, notes and favorites while recalculating macros

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad84da6d08832f9354fa8e85c5c105