### PR TITLE
feat: show full daily RSK percent and colors

### DIFF
--- a/MedTrackApp/__tests__/nutritionAggregates.test.ts
+++ b/MedTrackApp/__tests__/nutritionAggregates.test.ts
@@ -5,6 +5,7 @@ import {
   computeRskPercents,
 } from '../src/nutrition/aggregate';
 import { MealType, NormalizedEntry } from '../src/nutrition/types';
+import { colorForDayPct } from '../src/utils/rsk';
 
 describe('nutrition aggregates', () => {
   const emptyMeals: Record<MealType, NormalizedEntry[]> = {
@@ -80,5 +81,38 @@ describe('nutrition aggregates', () => {
     const res = computeRskPercents(mealCal, 1000)!;
     expect(res.day).toBe(5);
     expect(res.byMeal).toEqual({ breakfast: 3, lunch: 0, dinner: 2, snack: 0 });
+  });
+
+  it('handles surplus day and distributes percents to meals', () => {
+    const mealCal = { breakfast: 300, lunch: 900, dinner: 900, snack: 0 };
+    const res = computeRskPercents(mealCal, 2000)!;
+    expect(res.day).toBe(105);
+    expect(res.byMeal).toEqual({ breakfast: 15, lunch: 45, dinner: 45, snack: 0 });
+    expect(Object.values(res.byMeal).reduce((a, b) => a + b, 0)).toBe(105);
+  });
+
+  describe('day percent color thresholds', () => {
+    it('0 of 2000 -> 0% and green', () => {
+      const res = computeRskPercents(
+        { breakfast: 0, lunch: 0, dinner: 0, snack: 0 },
+        2000,
+      )!;
+      expect(res.day).toBe(0);
+      expect(colorForDayPct(0)).toBe('#22C55E');
+    });
+
+    it('2000 of 2000 -> 100% and amber', () => {
+      const mealCal = { breakfast: 1000, lunch: 1000, dinner: 0, snack: 0 };
+      const res = computeRskPercents(mealCal, 2000)!;
+      expect(res.day).toBe(100);
+      expect(colorForDayPct(100)).toBe('#F59E0B');
+    });
+
+    it('2500 of 2000 -> 125% and red', () => {
+      const mealCal = { breakfast: 1000, lunch: 1000, dinner: 500, snack: 0 };
+      const res = computeRskPercents(mealCal, 2000)!;
+      expect(res.day).toBe(125);
+      expect(colorForDayPct(125)).toBe('#EF4444');
+    });
   });
 });

--- a/MedTrackApp/src/components/MacronutrientSummary.tsx
+++ b/MedTrackApp/src/components/MacronutrientSummary.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { formatNumber } from '../utils/number';
+import { colorForDayPct } from '../utils/rsk';
 
 export type MacronutrientSummaryProps = {
   caloriesConsumed: number;
+  targetCalories?: number;
   rskPercent?: number;
   protein: number;
   fat: number;
@@ -12,22 +14,24 @@ export type MacronutrientSummaryProps = {
 
 const MacronutrientSummary: React.FC<MacronutrientSummaryProps> = ({
   caloriesConsumed,
+  targetCalories,
   rskPercent,
   protein,
   fat,
   carbs,
 }) => {
-  const percent = rskPercent;
-  const barPercent = percent !== undefined ? Math.min(percent, 100) : 0;
-
-  let barColor = '#22C55E';
-  if (percent !== undefined) {
-    if (percent > 120) {
-      barColor = '#EF4444';
-    } else if (percent > 100) {
-      barColor = '#F59E0B';
-    }
-  }
+  const dayPctExact =
+    targetCalories && targetCalories > 0
+      ? (caloriesConsumed / targetCalories) * 100
+      : null;
+  const fill =
+    dayPctExact !== null
+      ? Math.max(0, Math.min(1, caloriesConsumed / targetCalories!))
+      : 0;
+  const percentLabel =
+    rskPercent !== undefined ? `${rskPercent}%` : '—';
+  const barColor =
+    dayPctExact !== null ? colorForDayPct(dayPctExact) : '#22C55E';
 
   return (
     <View style={styles.container}>
@@ -53,7 +57,7 @@ const MacronutrientSummary: React.FC<MacronutrientSummaryProps> = ({
         <View style={styles.column}>
           <Text style={styles.label}>РСК</Text>
           <Text style={styles.value} testID="summary-rsk">
-            {percent !== undefined ? `${percent}%` : '—'}
+            {percentLabel}
           </Text>
         </View>
         <View style={styles.column}>
@@ -68,17 +72,17 @@ const MacronutrientSummary: React.FC<MacronutrientSummaryProps> = ({
       </View>
       <View style={styles.progressRow}>
         <View style={styles.progressBar}>
-          {percent !== undefined && (
+          {dayPctExact !== null && (
             <View
               style={[
                 styles.progressFill,
-                { width: `${barPercent}%`, backgroundColor: barColor },
+                { width: `${fill * 100}%`, backgroundColor: barColor },
               ]}
             />
           )}
         </View>
         <Text style={styles.percentage} testID="summary-bar-pct">
-          {percent !== undefined ? `${percent}%` : '—'}
+          {percentLabel}
         </Text>
       </View>
     </View>

--- a/MedTrackApp/src/nutrition/aggregate.ts
+++ b/MedTrackApp/src/nutrition/aggregate.ts
@@ -69,9 +69,10 @@ export const computeRskPercents = (
   const keys: MealType[] = ['breakfast', 'lunch', 'dinner', 'snack'];
   const dayCal = keys.reduce((sum, k) => sum + mealCal[k], 0);
 
-  const clamp = (n: number) => Math.max(0, Math.min(100, n));
+  const dayPctExact = (dayCal / targetCal) * 100;
+  const dayPctShown = Math.round(dayPctExact);
 
-  const dayPctShown = clamp(Math.round((dayCal / targetCal) * 100));
+  const clamp = (n: number) => Math.max(0, Math.min(1000, n));
 
   let lastNonEmpty: MealType | null = null;
   keys.forEach(k => {

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -165,6 +165,7 @@ const DietScreen: React.FC = () => {
         />
         <MacronutrientSummary
           caloriesConsumed={dayTotals.calories}
+          targetCalories={targetCalories}
           rskPercent={dayRskDisplay}
           protein={dayTotals.protein}
           fat={dayTotals.fat}

--- a/MedTrackApp/src/utils/rsk.ts
+++ b/MedTrackApp/src/utils/rsk.ts
@@ -1,0 +1,5 @@
+export const colorForDayPct = (pct: number): string => {
+  if (pct === 100) return '#F59E0B';
+  if (pct > 100) return '#EF4444';
+  return '#22C55E';
+};


### PR DESCRIPTION
## Summary
- compute RSK percents without clamping to 100 and assign residual to last non-empty meal
- render daily summary bar with capped fill and color thresholds for deficit/target/surplus
- add unit tests for new percentage logic and color function

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad93e512f4832f834f8f990d44fd22