### PR TITLE
feat: streamline meal actions and copy/clear behavior

### DIFF
--- a/MedTrackApp/__tests__/AccountScreen.test.tsx
+++ b/MedTrackApp/__tests__/AccountScreen.test.tsx
@@ -8,6 +8,8 @@ import AccountScreen from '../src/screens/AccountScreen/AccountScreen';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { launchImageLibrary } from 'react-native-image-picker';
 
+jest.setTimeout(20000);
+
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ goBack: jest.fn() }),
 }));

--- a/MedTrackApp/src/components/MealPanel.tsx
+++ b/MedTrackApp/src/components/MealPanel.tsx
@@ -27,8 +27,7 @@ export type MealPanelProps = {
   onAdd?: () => void;
   onSelectEntry?: (id: string) => void;
   onCopyFromYesterday?: () => void;
-  onSaveMeal?: () => void;
-  onCamera?: () => void;
+  onClearMeal?: () => void;
 };
 
 const MealPanel: React.FC<MealPanelProps> = ({
@@ -44,8 +43,7 @@ const MealPanel: React.FC<MealPanelProps> = ({
   onAdd,
   onSelectEntry,
   onCopyFromYesterday,
-  onSaveMeal,
-  onCamera,
+  onClearMeal,
 }) => {
   const [expanded, setExpanded] = useState(false);
   const toggle = () => setExpanded(prev => !prev);
@@ -128,20 +126,13 @@ const MealPanel: React.FC<MealPanelProps> = ({
             )}
           </View>
           <View style={styles.actionBar}>
-            <TouchableOpacity
-              style={styles.action}
-              onPress={onCopyFromYesterday}
-            >
+            <TouchableOpacity style={styles.action} onPress={onCopyFromYesterday}>
               <Icon name="content-copy" size={16} color="#22C55E" />
               <Text style={styles.actionText}>Копировать из вчера</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={styles.action} onPress={onSaveMeal}>
-              <Icon name="bookmark-plus-outline" size={16} color="#22C55E" />
-              <Text style={styles.actionText}>Сохранить Еду</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.action} onPress={onCamera}>
-              <Icon name="camera" size={16} color="#22C55E" />
-              <Text style={styles.actionText}>Камера</Text>
+            <TouchableOpacity style={styles.action} onPress={onClearMeal}>
+              <Icon name="delete-outline" size={16} color="#EF4444" />
+              <Text style={[styles.actionText, styles.destructiveText]}>Очистить приём пищи</Text>
             </TouchableOpacity>
           </View>
         </>
@@ -257,7 +248,7 @@ const styles = StyleSheet.create({
   },
   actionBar: {
     flexDirection: 'row',
-    justifyContent: 'space-around',
+    justifyContent: 'space-between',
     paddingVertical: 8,
     borderTopWidth: 1,
     borderTopColor: '#323232',
@@ -270,6 +261,9 @@ const styles = StyleSheet.create({
     color: '#22C55E',
     fontSize: 12,
     marginLeft: 4,
+  },
+  destructiveText: {
+    color: '#EF4444',
   },
 });
 

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -137,11 +137,11 @@ const DietScreen: React.FC = () => {
 
     Alert.alert(
       'Скопировать из вчера?',
-      `Добавить все продукты из вчерашнего приема пищи? Текущие продукты сохранятся.`,
+      `Продукты из вчерашнего ${mealName} будут ДОБАВЛЕНЫ к сегодняшнему ${mealName}. Текущие записи сохранятся.`,
       [
         { text: 'Отмена', style: 'cancel' },
         {
-          text: 'Скопировать',
+          text: 'Добавить',
           onPress: () => {
             setEntriesByDate(prev => {
               const day = prev[selectedDate] || createEmptyDay();
@@ -149,12 +149,47 @@ const DietScreen: React.FC = () => {
                 ...day,
                 [meal]: [
                   ...day[meal],
-                  ...prevMeal.map(e => ({ ...e, id: Math.random().toString() })),
+                  ...prevMeal.map(e => ({
+                    ...e,
+                    id: Math.random().toString(),
+                    createdAt: Date.now(),
+                    mealType: meal,
+                  })),
                 ],
               };
               return { ...prev, [selectedDate]: updated };
             });
             showToast('Скопировано');
+          },
+        },
+      ],
+    );
+  };
+
+  const handleClearMeal = (meal: MealType) => {
+    const mealName = mealMeta[meal].title;
+    const day = entriesByDate[selectedDate] || createEmptyDay();
+
+    if (day[meal].length === 0) {
+      showToast('Записей нет');
+      return;
+    }
+
+    Alert.alert(
+      'Очистить приём пищи?',
+      `Все продукты из ${mealName} будут удалены.`,
+      [
+        { text: 'Отмена', style: 'cancel' },
+        {
+          text: 'Очистить',
+          style: 'destructive',
+          onPress: () => {
+            setEntriesByDate(prev => {
+              const day = prev[selectedDate] || createEmptyDay();
+              const updated = { ...day, [meal]: [] };
+              return { ...prev, [selectedDate]: updated };
+            });
+            showToast('Очищено');
           },
         },
       ],
@@ -239,6 +274,7 @@ const DietScreen: React.FC = () => {
             onAdd={() => setActiveMeal(meal.mealKey)}
             onSelectEntry={id => handleSelectEntry(meal.mealKey, id)}
             onCopyFromYesterday={() => handleCopyMealFromYesterday(meal.mealKey)}
+            onClearMeal={() => handleClearMeal(meal.mealKey)}
           />
         ))}
       </ScrollView>


### PR DESCRIPTION
## Summary
- replace meal card action row with "Копировать из вчера" and destructive "Очистить приём пищи"
- implement per-meal copy from yesterday with deep-copy and confirm dialogs
- add meal clearing logic with alerts and toast messages
- increase AccountScreen test timeout for reliability

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook useMemo has a missing dependency, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aed2472da8832fac1730c39b44d4df