### PR TITLE
fix: avoid duplicate toast when adding food

### DIFF
--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -210,8 +210,6 @@ const DietScreen: React.FC = () => {
       };
       return { ...prev, [selectedDate]: updated };
     });
-    showToast(`Добавлено в ${mealMeta[entry.mealType].title}`);
-    setActiveMeal(null);
   };
 
   const handleSelectEntry = (meal: MealType, id: string) => {


### PR DESCRIPTION
## Summary
- avoid double toast on meal addition by removing DietScreen toast and relying on modal toast

## Testing
- `npm test`
- `npm run lint` *(fails: The 'mealMeta' object makes the dependencies of useMemo Hook change on every render...)*

------
https://chatgpt.com/codex/tasks/task_e_68af10f8cba8832fa505cc82be9136b4