### PR TITLE
feat: add neon macro rings for daily nutrition stats

### DIFF
--- a/MedTrackApp/src/navigation/types.ts
+++ b/MedTrackApp/src/navigation/types.ts
@@ -31,6 +31,6 @@ export type RootStackParamList = {
     entryId: string;
   };
   NutritionStats: {
-    weekStart: string;
+    selectedDate: string;
   };
 };

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -264,12 +264,10 @@ const DietScreen: React.FC = () => {
       return;
     }
     lastNavTime.current = now;
-    const start = addDays(new Date(), weekOffset * 7);
-    const monday = addDays(start, -((start.getDay() + 6) % 7));
     navigation.navigate('NutritionStats', {
-      weekStart: format(monday, 'yyyy-MM-dd'),
+      selectedDate,
     });
-  }, [navigation, weekOffset]);
+  }, [navigation, selectedDate]);
 
   return (
     <SafeAreaView style={styles.container}>
@@ -288,7 +286,7 @@ const DietScreen: React.FC = () => {
           hitSlop={8}
           accessibilityRole="button"
           accessibilityLabel="Открыть статистику питания"
-          accessibilityHint="Нажмите, чтобы открыть расширенную статистику питания за неделю."
+          accessibilityHint="Нажмите, чтобы открыть расширенную статистику питания за выбранный день."
           android_ripple={{ color: 'rgba(255,255,255,0.08)' }}
           style={({ pressed }) => [{ opacity: pressed ? 0.8 : 1 }]}
           pointerEvents="auto"

--- a/MedTrackApp/src/screens/NutritionStats/MacroRing.tsx
+++ b/MedTrackApp/src/screens/NutritionStats/MacroRing.tsx
@@ -1,0 +1,249 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { View, Text, StyleSheet, AccessibilityInfo, Easing } from 'react-native';
+import Svg, {
+  Circle,
+  Defs,
+  LinearGradient,
+  Stop,
+  Filter,
+  FeGaussianBlur,
+} from 'react-native-svg';
+import { Animated } from 'react-native';
+
+interface Props {
+  label: string;
+  consumed: number;
+  target?: number;
+  type: 'calories' | 'protein' | 'fat' | 'carbs';
+}
+
+const MacroRing: React.FC<Props> = ({ label, consumed, target, type }) => {
+  const radius = 48;
+  const strokeWidth = 12;
+  const size = 120;
+  const circumference = 2 * Math.PI * radius;
+
+  const pct = target ? (consumed / target) * 100 : NaN;
+  const normalized = isFinite(pct) ? Math.min(Math.max(pct, 0), 100) : 0;
+  const displayPct = isFinite(pct)
+    ? Math.min(Math.max(Math.round(pct), 0), 300)
+    : null;
+
+  const [reduceMotion, setReduceMotion] = useState(false);
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
+    const sub = AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      setReduceMotion,
+    );
+    return () => {
+      // @ts-ignore
+      sub.remove && sub.remove();
+    };
+  }, []);
+
+  const progress = useRef(new Animated.Value(0)).current;
+  const glowOpacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const toValue = normalized;
+    const glowTo = target && isFinite(pct) ? 0.45 : 0;
+    if (reduceMotion) {
+      progress.setValue(toValue);
+      glowOpacity.setValue(glowTo);
+    } else {
+      Animated.timing(progress, {
+        toValue,
+        duration: 700,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: false,
+      }).start();
+      Animated.timing(glowOpacity, {
+        toValue: glowTo,
+        duration: 700,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [normalized, reduceMotion, pct, target, progress, glowOpacity]);
+
+  const offset = progress.interpolate({
+    inputRange: [0, 100],
+    outputRange: [circumference, 0],
+  });
+
+  const id = useRef(Math.random().toString(36).slice(2)).current;
+
+  let gradient = `gradGreen${id}`;
+  let glowColor = '#22C55E';
+  if (type === 'calories') {
+    if (pct > 110) {
+      gradient = `gradRed${id}`;
+      glowColor = '#EF4444';
+    } else if (pct > 100) {
+      gradient = `gradAmber${id}`;
+      glowColor = '#FFC107';
+    } else {
+      gradient = `gradGreen${id}`;
+      glowColor = '#22C55E';
+    }
+  } else if (type === 'fat') {
+    gradient = `gradRed${id}`;
+    glowColor = '#EF4444';
+  } else if (type === 'carbs') {
+    gradient = `gradBlue${id}`;
+    glowColor = '#3B82F6';
+  } else {
+    gradient = `gradGreen${id}`;
+    glowColor = '#22C55E';
+  }
+
+  const pctLabel = displayPct !== null ? `${displayPct}%` : '—%';
+
+  const accessibilityLabel = target && isFinite(pct)
+    ? `${label}: ${pctLabel} от цели за выбранный день`
+    : `${label}: цель не задана`;
+
+  const AnimatedCircle = useMemo(() => Animated.createAnimatedComponent(Circle), []);
+
+  return (
+    <View
+      style={styles.card}
+      accessible
+      accessibilityLabel={accessibilityLabel}
+    >
+      <View style={styles.svgWrapper}>
+        <Svg width={size} height={size} style={{ overflow: 'visible' }}>
+          <Defs>
+            <Filter
+              id={`ringGlow${id}`}
+              x="-50%"
+              y="-50%"
+              width="200%"
+              height="200%"
+            >
+              <FeGaussianBlur stdDeviation="6" />
+            </Filter>
+            <LinearGradient
+              id={`gradGreen${id}`}
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <Stop offset="0%" stopColor="#34D399" />
+              <Stop offset="100%" stopColor="#22C55E" />
+            </LinearGradient>
+            <LinearGradient
+              id={`gradAmber${id}`}
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <Stop offset="0%" stopColor="#FFD54F" />
+              <Stop offset="100%" stopColor="#FFC107" />
+            </LinearGradient>
+            <LinearGradient
+              id={`gradRed${id}`}
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <Stop offset="0%" stopColor="#FF6B6B" />
+              <Stop offset="100%" stopColor="#EF4444" />
+            </LinearGradient>
+            <LinearGradient
+              id={`gradBlue${id}`}
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <Stop offset="0%" stopColor="#60A5FA" />
+              <Stop offset="100%" stopColor="#3B82F6" />
+            </LinearGradient>
+          </Defs>
+          <Circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            stroke="rgba(255,255,255,0.12)"
+            strokeWidth={strokeWidth}
+            fill="none"
+          />
+          {target && isFinite(pct) && (
+            <>
+              <AnimatedCircle
+                cx={size / 2}
+                cy={size / 2}
+                r={radius}
+                stroke={glowColor}
+                strokeWidth={strokeWidth}
+                strokeLinecap="round"
+                fill="none"
+                strokeDasharray={`${circumference} ${circumference}`}
+                strokeDashoffset={offset}
+                opacity={glowOpacity}
+                filter={`url(#ringGlow${id})`}
+              />
+              <AnimatedCircle
+                cx={size / 2}
+                cy={size / 2}
+                r={radius}
+                stroke={`url(#${gradient})`}
+                strokeWidth={strokeWidth}
+                strokeLinecap="round"
+                fill="none"
+                strokeDasharray={`${circumference} ${circumference}`}
+                strokeDashoffset={offset}
+              />
+            </>
+          )}
+        </Svg>
+        <View style={styles.textWrapper} pointerEvents="none">
+          <Text style={styles.percent}>{pctLabel}</Text>
+          <Text style={styles.label}>{label}</Text>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    width: '48%',
+    backgroundColor: '#1E1E1E',
+    borderRadius: 20,
+    padding: 16,
+    marginBottom: 16,
+    alignItems: 'center',
+    overflow: 'visible',
+  },
+  svgWrapper: {
+    padding: 12,
+    overflow: 'visible',
+  },
+  textWrapper: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  percent: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  label: {
+    color: '#fff',
+    fontSize: 14,
+    marginTop: 4,
+  },
+});
+
+export default MacroRing;

--- a/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
+++ b/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
@@ -1,20 +1,18 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { RouteProp } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
-import Svg, { Circle } from 'react-native-svg';
-import { addDays, format, parseISO } from 'date-fns';
+import { addDays, format, parseISO, startOfWeek } from 'date-fns';
 
 import { RootStackParamList } from '../../navigation';
 import { loadDiary } from '../../nutrition/storage';
 import { aggregateMeals } from '../../nutrition/aggregate';
 import { formatNumber } from '../../utils/number';
 import WeeklyCaloriesCard from './WeeklyCaloriesCard';
+import MacroRing from './MacroRing';
 
 import { MealType, NormalizedEntry } from '../../nutrition/types';
 
 type RouteProps = RouteProp<RootStackParamList, 'NutritionStats'>;
-type NavProps = StackNavigationProp<RootStackParamList, 'NutritionStats'>;
 
 const targetCalories = 3300;
 const targetProtein = 120;
@@ -28,55 +26,8 @@ const createEmptyDay = (): Record<MealType, NormalizedEntry[]> => ({
   snack: [],
 });
 
-const NeonCircle: React.FC<{
-  percent: number;
-  label: string;
-  consumed: number;
-  target: number;
-  color: string;
-}> = ({ percent, label, consumed, target, color }) => {
-  const radius = 40;
-  const strokeWidth = 8;
-  const normalizedPercent = Math.min(percent, 100);
-  const circumference = 2 * Math.PI * radius;
-  const strokeDashoffset =
-    circumference - (normalizedPercent / 100) * circumference;
-  const pctLabel = `${Math.round(percent)}%`;
-
-  return (
-    <View style={styles.card}> 
-      <Svg width={radius * 2} height={radius * 2}>
-        <Circle
-          cx={radius}
-          cy={radius}
-          r={radius}
-          stroke="#333"
-          strokeWidth={strokeWidth}
-          fill="none"
-        />
-        <Circle
-          cx={radius}
-          cy={radius}
-          r={radius}
-          stroke={color}
-          strokeWidth={strokeWidth}
-          strokeLinecap="round"
-          fill="none"
-          strokeDasharray={`${circumference} ${circumference}`}
-          strokeDashoffset={strokeDashoffset}
-        />
-      </Svg>
-      <View style={styles.circleContent}>
-        <Text style={styles.circlePercent}>{pctLabel}</Text>
-        <Text style={styles.circleLabel}>{label}</Text>
-        <Text style={styles.circleSub}>{`${formatNumber(consumed)}/${formatNumber(target)}${label === 'Калории' ? ' ккал' : ' г'}`}</Text>
-      </View>
-    </View>
-  );
-};
-
-const NutritionStatsScreen: React.FC<{ route: RouteProps; navigation: NavProps }> = ({ route }) => {
-  const { weekStart } = route.params;
+const NutritionStatsScreen: React.FC<{ route: RouteProps }> = ({ route }) => {
+  const { selectedDate } = route.params;
   const [entries, setEntries] = useState<Record<string, Record<MealType, NormalizedEntry[]>>>({});
 
   useEffect(() => {
@@ -84,17 +35,22 @@ const NutritionStatsScreen: React.FC<{ route: RouteProps; navigation: NavProps }
   }, []);
 
   const weekDates = useMemo(() => {
-    const start = parseISO(weekStart);
+    const start = startOfWeek(parseISO(selectedDate), { weekStartsOn: 1 });
     return Array.from({ length: 7 }).map((_, i) => {
       const d = addDays(start, i);
       return format(d, 'yyyy-MM-dd');
     });
-  }, [weekStart]);
+  }, [selectedDate]);
 
   const dailyTotals = weekDates.map(date => {
     const dayEntries = entries[date] || createEmptyDay();
     return aggregateMeals(dayEntries).dayTotals;
   });
+
+  const selectedDayTotals = useMemo(() => {
+    const dayEntries = entries[selectedDate] || createEmptyDay();
+    return aggregateMeals(dayEntries).dayTotals;
+  }, [entries, selectedDate]);
 
   const weekTotals = dailyTotals.reduce(
     (sum, d) => ({
@@ -109,38 +65,34 @@ const NutritionStatsScreen: React.FC<{ route: RouteProps; navigation: NavProps }
   const cards = [
     {
       label: 'Калории',
-      color: '#FFC107',
-      consumed: weekTotals.calories,
-      target: targetCalories * 7,
-      percent: (weekTotals.calories / (targetCalories * 7)) * 100,
+      type: 'calories' as const,
+      consumed: selectedDayTotals.calories,
+      target: targetCalories,
     },
     {
       label: 'Белки',
-      color: '#22C55E',
-      consumed: weekTotals.protein,
-      target: targetProtein * 7,
-      percent: (weekTotals.protein / (targetProtein * 7)) * 100,
+      type: 'protein' as const,
+      consumed: selectedDayTotals.protein,
+      target: targetProtein,
     },
     {
       label: 'Жиры',
-      color: '#EF4444',
-      consumed: weekTotals.fat,
-      target: targetFat * 7,
-      percent: (weekTotals.fat / (targetFat * 7)) * 100,
+      type: 'fat' as const,
+      consumed: selectedDayTotals.fat,
+      target: targetFat,
     },
     {
       label: 'Углеводы',
-      color: '#3B82F6',
-      consumed: weekTotals.carbs,
-      target: targetCarbs * 7,
-      percent: (weekTotals.carbs / (targetCarbs * 7)) * 100,
+      type: 'carbs' as const,
+      consumed: selectedDayTotals.carbs,
+      target: targetCarbs,
     },
   ];
 
   const labels = ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'];
   const dailyData = labels.map((label, i) => ({
     label,
-    calories: dailyTotals[i].calories,
+    calories: dailyTotals[i]?.calories ?? 0,
     target: targetCalories,
   }));
 
@@ -148,13 +100,12 @@ const NutritionStatsScreen: React.FC<{ route: RouteProps; navigation: NavProps }
     <ScrollView contentContainerStyle={styles.container}>
       <View style={styles.cardRow}>
         {cards.map(c => (
-          <NeonCircle
+          <MacroRing
             key={c.label}
-            percent={c.percent}
             label={c.label}
             consumed={c.consumed}
             target={c.target}
-            color={c.color}
+            type={c.type}
           />
         ))}
       </View>
@@ -196,38 +147,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     justifyContent: 'space-between',
-  },
-  card: {
-    width: '48%',
-    backgroundColor: '#1E1E1E',
-    borderRadius: 20,
-    padding: 16,
-    marginBottom: 16,
-    alignItems: 'center',
-  },
-  circleContent: {
-    position: 'absolute',
-    alignItems: 'center',
-    justifyContent: 'center',
-    top: 16,
-    left: 0,
-    right: 0,
-    bottom: 0,
-  },
-  circlePercent: {
-    color: '#fff',
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
-  circleLabel: {
-    color: '#fff',
-    marginTop: 4,
-    fontSize: 14,
-  },
-  circleSub: {
-    color: 'rgba(255,255,255,0.6)',
-    fontSize: 12,
-    marginTop: 2,
   },
   summaryCard: {
     backgroundColor: '#1E1E1E',


### PR DESCRIPTION
## Summary
- pass selected date to nutrition stats screen
- show neon-glow macro rings with percentage labels
- animate rings and highlight calorie thresholds per day

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b578c81c9c832fb48cf97fd111b60a