### PR TITLE
Replace weekly deviation card with compact nutrition summary row

### DIFF
--- a/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
+++ b/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
@@ -23,8 +23,8 @@ import { addDays, format, parseISO } from 'date-fns';
 import { RootStackParamList } from '../../navigation';
 import { loadDiary } from '../../nutrition/storage';
 import { aggregateMeals } from '../../nutrition/aggregate';
-import { formatNumber } from '../../utils/number';
 import WeeklyCaloriesCard from './WeeklyCaloriesCard';
+import WeeklyMacrosRow from './WeeklyMacrosRow';
 import { MealType, NormalizedEntry } from '../../nutrition/types';
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
@@ -293,28 +293,7 @@ const NutritionStatsScreen: React.FC<{
 
       <WeeklyCaloriesCard days={dailyData} />
 
-      <View style={styles.summaryCard}>
-        <View style={styles.summaryRow}>
-          <Text style={styles.summaryLabel}>За неделю</Text>
-          <Text style={styles.summaryValue}>
-            {formatNumber(weekTotals.calories)} ккал, {formatNumber(weekTotals.protein)} Б, {formatNumber(weekTotals.fat)} Ж, {formatNumber(weekTotals.carbs)} У
-          </Text>
-        </View>
-        <View style={styles.summaryRow}>
-          <Text style={styles.summaryLabel}>Отклонение от цели</Text>
-          <Text
-            style={[
-              styles.summaryValue,
-              {
-                color:
-                  weekTotals.calories - kcalTarget * 7 >= 0 ? '#EF4444' : '#22C55E',
-              },
-            ]}
-          >
-            {formatNumber(weekTotals.calories - kcalTarget * 7)} ккал
-          </Text>
-        </View>
-      </View>
+      <WeeklyMacrosRow totals={weekTotals} kcalTarget={kcalTarget} />
     </ScrollView>
   );
 };
@@ -363,26 +342,6 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 14,
     marginTop: 4,
-  },
-  summaryCard: {
-    backgroundColor: '#1E1E1E',
-    padding: 16,
-    borderRadius: 20,
-    marginBottom: 32,
-  },
-  summaryRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 8,
-  },
-  summaryLabel: {
-    color: 'rgba(255,255,255,0.6)',
-    fontSize: 14,
-  },
-  summaryValue: {
-    color: '#fff',
-    fontSize: 14,
-    fontWeight: 'bold',
   },
 });
 

--- a/MedTrackApp/src/screens/NutritionStats/WeeklyMacrosRow.tsx
+++ b/MedTrackApp/src/screens/NutritionStats/WeeklyMacrosRow.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { formatNumber } from '../../utils/number';
+
+interface Totals {
+  calories: number;
+  protein: number;
+  fat: number;
+  carbs: number;
+}
+
+interface Props {
+  totals: Totals;
+  kcalTarget?: number;
+}
+
+const WeeklyMacrosRow: React.FC<Props> = ({ totals, kcalTarget }) => {
+  const rskPct = kcalTarget && kcalTarget > 0 ? (totals.calories / (kcalTarget * 7)) * 100 : null;
+  const rskDisplay = rskPct === null ? '—%' : `${formatNumber(Math.round(rskPct), 0)}%`;
+
+  return (
+    <View style={styles.container}>
+      <View
+        style={styles.column}
+        accessible
+        accessibilityLabel={`Жиры за неделю: ${formatNumber(totals.fat, 1)} грамма`}
+      >
+        <Text style={styles.label}>Жиры</Text>
+        <Text style={styles.value}>{formatNumber(totals.fat, 1)}</Text>
+      </View>
+      <View
+        style={styles.column}
+        accessible
+        accessibilityLabel={`Углеводы за неделю: ${formatNumber(totals.carbs, 1)} грамма`}
+      >
+        <Text style={styles.label}>Углев</Text>
+        <Text style={styles.value}>{formatNumber(totals.carbs, 1)}</Text>
+      </View>
+      <View
+        style={styles.column}
+        accessible
+        accessibilityLabel={`Белки за неделю: ${formatNumber(totals.protein, 1)} грамма`}
+      >
+        <Text style={styles.label}>Белк</Text>
+        <Text style={styles.value}>{formatNumber(totals.protein, 1)}</Text>
+      </View>
+      <View
+        style={styles.column}
+        accessible
+        accessibilityLabel={
+          rskPct === null
+            ? 'РСК за неделю: цель не задана'
+            : `РСК за неделю: ${formatNumber(Math.round(rskPct), 0)} процентов`
+        }
+      >
+        <Text style={styles.label}>РСК</Text>
+        <Text style={styles.value}>{rskDisplay}</Text>
+      </View>
+      <View
+        style={styles.column}
+        accessible
+        accessibilityLabel={`Калории за неделю: ${formatNumber(totals.calories, 0)} килокалорий`}
+      >
+        <Text style={styles.label}>Калории</Text>
+        <Text style={styles.value}>{formatNumber(totals.calories, 0)}</Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    backgroundColor: '#1E1E1E',
+    borderRadius: 16,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    marginBottom: 32,
+  },
+  column: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  label: {
+    color: 'rgba(255,255,255,0.6)',
+    fontSize: 12,
+  },
+  value: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});
+
+export default WeeklyMacrosRow;
+


### PR DESCRIPTION
## Summary
- replace "За неделю / Отклонение от цели" card on NutritionStatsScreen with compact KБЖУ row
- add WeeklyMacrosRow component showing weekly fat, carbs, protein, RSK and calories totals

## Testing
- `npm test`
- `npm run lint` *(fails: 5 errors, 121 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b6027e35c8832f8f92f8a1514540a2