### PR TITLE
Fix NutritionStats overscroll background color

### DIFF
--- a/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
+++ b/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
@@ -276,7 +276,7 @@ const NutritionStatsScreen: React.FC<{
   }));
 
   return (
-    <ScrollView contentContainerStyle={styles.container}>
+    <ScrollView style={styles.screen} contentContainerStyle={styles.container}>
       <RingDefs />
       <View style={styles.cardRow}>
         {cards.map(c => (
@@ -299,9 +299,14 @@ const NutritionStatsScreen: React.FC<{
 };
 
 const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
   container: {
     padding: 16,
     backgroundColor: '#000',
+    flexGrow: 1,
   },
   cardRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- ensure NutritionStats screen overscroll shows black background

## Testing
- `npm test`
- `npm run lint` *(fails: 124 problems, 7 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6abcb1798832fad5c16132ab666fa