### PR TITLE
feat: add neon glow to nutrition progress bars

### DIFF
--- a/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
+++ b/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
@@ -85,7 +85,6 @@ const ProgressRing: React.FC<{
   const finalOffset = circumference * (1 - p);
 
   const offsetAnim = useRef(new Animated.Value(circumference)).current;
-  const glowOpacity = useRef(new Animated.Value(0)).current;
   const [reduceMotion, setReduceMotion] = useState(false);
 
   useEffect(() => {
@@ -103,29 +102,19 @@ const ProgressRing: React.FC<{
   useEffect(() => {
     if (rawPct === null) {
       offsetAnim.setValue(circumference);
-      glowOpacity.setValue(0);
       return;
     }
     if (reduceMotion) {
       offsetAnim.setValue(finalOffset);
-      glowOpacity.setValue(0.45);
     } else {
-      Animated.parallel([
-        Animated.timing(offsetAnim, {
-          toValue: finalOffset,
-          duration: 700,
-          easing: Easing.out(Easing.cubic),
-          useNativeDriver: false,
-        }),
-        Animated.timing(glowOpacity, {
-          toValue: 0.45,
-          duration: 700,
-          easing: Easing.out(Easing.cubic),
-          useNativeDriver: false,
-        }),
-      ]).start();
+      Animated.timing(offsetAnim, {
+        toValue: finalOffset,
+        duration: 700,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: false,
+      }).start();
     }
-  }, [finalOffset, rawPct, reduceMotion, offsetAnim, glowOpacity, circumference]);
+  }, [finalOffset, rawPct, reduceMotion, offsetAnim, circumference]);
 
   const accessibilityLabel =
     rawPct === null
@@ -156,7 +145,7 @@ const ProgressRing: React.FC<{
                 fill="none"
                 strokeDasharray={circumference}
                 strokeDashoffset={offsetAnim}
-                opacity={glowOpacity}
+                opacity={0.45}
                 filter="url(#ringGlow)"
                 transform={`rotate(-90 ${size / 2} ${size / 2})`}
               />

--- a/MedTrackApp/src/screens/NutritionStats/WeeklyCaloriesCard.tsx
+++ b/MedTrackApp/src/screens/NutritionStats/WeeklyCaloriesCard.tsx
@@ -152,6 +152,11 @@ const WeeklyCaloriesCard: React.FC<Props> = ({ days, onAddFood }) => {
                     {
                       height: barHeight,
                       backgroundColor: color,
+                      shadowColor: color,
+                      shadowOffset: { width: 0, height: 0 },
+                      shadowOpacity: color === 'transparent' ? 0 : 0.8,
+                      shadowRadius: 8,
+                      elevation: color === 'transparent' ? 0 : 6,
                     },
                   ]}
                 />
@@ -243,6 +248,7 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
     marginBottom: 12,
     paddingHorizontal: 4,
+    overflow: 'visible',
   },
   barWrapper: {
     width: 16,
@@ -250,6 +256,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'flex-end',
     marginHorizontal: 6,
+    overflow: 'visible',
   },
   track: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- add static neon glow to NutritionStats progress rings
- add glowing shadows to weekly calorie bars without clipping

## Testing
- `npm test`
- `npm run lint` *(fails: existing errors in ReminderEdit.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b23cfff4832f8f10bfc0782eea3c