### PR TITLE
feat: add neon glows to nutrition progress visuals

### DIFF
--- a/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
+++ b/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
@@ -248,7 +248,7 @@ const NutritionStatsScreen: React.FC<{
       value: dayTotals.protein,
       target: proteinTarget,
       gradient: 'gradGreen',
-      glow: '#00FFFF',
+      glow: '#22C55E',
     },
     {
       key: 'fat',
@@ -256,7 +256,7 @@ const NutritionStatsScreen: React.FC<{
       value: dayTotals.fat,
       target: fatTarget,
       gradient: 'gradRed',
-      glow: '#FF00FF',
+      glow: '#EF4444',
     },
     {
       key: 'carbs',
@@ -264,7 +264,7 @@ const NutritionStatsScreen: React.FC<{
       value: dayTotals.carbs,
       target: carbsTarget,
       gradient: 'gradBlue',
-      glow: '#FF8000',
+      glow: '#3B82F6',
     },
   ];
 

--- a/MedTrackApp/src/screens/NutritionStats/WeeklyCaloriesCard.tsx
+++ b/MedTrackApp/src/screens/NutritionStats/WeeklyCaloriesCard.tsx
@@ -152,6 +152,10 @@ const WeeklyCaloriesCard: React.FC<Props> = ({ days, onAddFood }) => {
                     {
                       height: barHeight,
                       backgroundColor: color,
+                      shadowColor: color,
+                      shadowOffset: { width: 0, height: 0 },
+                      shadowOpacity: 0.4,
+                      shadowRadius: 6,
                     },
                   ]}
                 />
@@ -282,7 +286,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     height: 10,
     borderRadius: 5,
-    overflow: 'hidden',
     marginBottom: 8,
   },
   segment: {
@@ -290,12 +293,28 @@ const styles = StyleSheet.create({
   },
   segmentDeficit: {
     backgroundColor: '#22C55E',
+    borderTopLeftRadius: 5,
+    borderBottomLeftRadius: 5,
+    shadowColor: '#22C55E',
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.4,
+    shadowRadius: 4,
   },
   segmentNorm: {
     backgroundColor: '#FFC107',
+    shadowColor: '#FFC107',
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4,
   },
   segmentSurplus: {
     backgroundColor: '#EF4444',
+    borderTopRightRadius: 5,
+    borderBottomRightRadius: 5,
+    shadowColor: '#EF4444',
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.4,
+    shadowRadius: 4,
   },
   chipsRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- add per-metric glow colors to progress rings
- give weekly calories bars and segment bar a soft halo using matching colors

## Testing
- `npm test`
- `npm run lint` *(fails: React hooks dependency and other existing warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b26de714832f8a79473be0346c23