### PR TITLE
refactor: extract NutritionStatsScreen styles

### DIFF
--- a/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
+++ b/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
@@ -1,14 +1,6 @@
 // screens/nutrition/NutritionStatsScreen.tsx
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  ScrollView,
-  AccessibilityInfo,
-  Animated,
-  Easing,
-} from 'react-native';
+import { View, Text, ScrollView, AccessibilityInfo, Animated, Easing } from 'react-native';
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import Svg, { Circle } from 'react-native-svg';
@@ -20,6 +12,7 @@ import { aggregateMeals } from '../../nutrition/aggregate';
 import WeeklyCaloriesCard from './WeeklyCaloriesCard';
 import WeeklyMacrosRow from './WeeklyMacrosRow';
 import { MealType, NormalizedEntry } from '../../nutrition/types';
+import { styles } from './styles';
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
@@ -256,57 +249,5 @@ const NutritionStatsScreen: React.FC<{
     </ScrollView>
   );
 };
-
-const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    backgroundColor: '#000',
-  },
-  container: {
-    padding: 16,
-    backgroundColor: '#000',
-    flexGrow: 1,
-  },
-  cardRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-  },
-  tile: {
-    width: '48%',
-    backgroundColor: '#1C1C1E',
-    borderRadius: 20,
-    padding: 16,
-    marginBottom: 16,
-    alignItems: 'center',
-    overflow: 'visible',
-  },
-  ringWrap: {
-    width: 120,
-    height: 120,
-    overflow: 'visible',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  labelCenter: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-    left: 0,
-    right: 0,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  percent: {
-    color: '#fff',
-    fontSize: 20,
-    fontWeight: '600',
-  },
-  label: {
-    color: '#fff',
-    fontSize: 14,
-    marginTop: 4,
-  },
-});
 
 export default NutritionStatsScreen;

--- a/MedTrackApp/src/screens/NutritionStats/styles.ts
+++ b/MedTrackApp/src/screens/NutritionStats/styles.ts
@@ -1,0 +1,54 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  container: {
+    padding: 16,
+    backgroundColor: '#000',
+    flexGrow: 1,
+  },
+  cardRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  },
+  tile: {
+    width: '48%',
+    backgroundColor: '#1C1C1E',
+    borderRadius: 20,
+    padding: 16,
+    marginBottom: 16,
+    alignItems: 'center',
+    overflow: 'visible',
+  },
+  ringWrap: {
+    width: 120,
+    height: 120,
+    overflow: 'visible',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  labelCenter: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  percent: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  label: {
+    color: '#fff',
+    fontSize: 14,
+    marginTop: 4,
+  },
+});
+


### PR DESCRIPTION
## Summary
- move static NutritionStatsScreen styles into a dedicated styles.ts
- import shared styles into NutritionStatsScreen instead of inline definitions

## Testing
- `npm test`
- `npm run lint` *(fails: Inline style warning and existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0835615c832f8d4367873193ff8b