### PR TITLE
Align MedCalendarScreen safe area with DietScreen

### DIFF
--- a/MedTrackApp/src/screens/MedCalendarScreen/MedCalendarScreen.tsx
+++ b/MedTrackApp/src/screens/MedCalendarScreen/MedCalendarScreen.tsx
@@ -282,16 +282,13 @@ const MedCalendarScreen: React.FC = () => {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      {/* НЕ translucent — пусть система сама отдаст корректный insets.top */}
-      <StatusBar translucent={false} backgroundColor="#000" barStyle="light-content" />
+      <StatusBar
+        translucent={Platform.OS === 'ios'}
+        backgroundColor={Platform.OS === 'android' ? '#000' : 'transparent'}
+        barStyle="light-content"
+      />
 
-      {/* iOS: top+bottom; Android: вообще без edges (ни верха, ни низа),
-          чтобы не добавлять «чёрные прослойки». */}
-      <SafeAreaView
-        edges={Platform.OS === 'ios' ? ['top', 'bottom'] : []}
-        style={[styles.container, Platform.OS === 'android' && { paddingBottom: 0 }]}
-      >
-        {/* На Android даём только нужный верхний отступ вручную */}
+      <SafeAreaView edges={Platform.OS === 'ios' ? ['top', 'bottom'] : []} style={styles.container}>
         <View style={{ flex: 1, paddingTop: androidTopPad }}>
           {/* Week Navigation */}
           <View style={styles.weekHeader}>

--- a/MedTrackApp/src/screens/MedCalendarScreen/styles.ts
+++ b/MedTrackApp/src/screens/MedCalendarScreen/styles.ts
@@ -1,10 +1,9 @@
-import { StyleSheet, Platform, StatusBar } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 export const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#121212',
-    paddingTop: Platform.OS === 'ios' ? 10 : StatusBar.currentHeight,
   },
   weekHeader: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- handle Android top inset manually and use SafeAreaView on iOS
- remove hardcoded paddingTop from MedCalendar styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba0d44b2e8832f9583bee9ae638d2f