### PR TITLE
feat: improve empty day UX in medication calendar

### DIFF
--- a/MedTrackApp/src/components/MedicationDayStatsButton.tsx
+++ b/MedTrackApp/src/components/MedicationDayStatsButton.tsx
@@ -74,6 +74,24 @@ const MedicationDayStatsButton: React.FC<Props> = ({
 
   const halo = percent > 100;
   const color = "#00E5FF";
+  if (scheduledCount === 0) {
+    return (
+      <Pressable
+        onPress={onPress}
+        android_ripple={{ color: 'rgba(255,255,255,0.08)' }}
+        style={({ pressed }) => [
+          styles.container,
+          styles.emptyContainer,
+          style,
+          { opacity: pressed ? 0.8 : 1 },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel="Дневная статистика. Нет запланированных приёмов."
+      >
+        <Text style={[styles.title, styles.emptyTitle]}>Нет запланированных приёмов</Text>
+      </Pressable>
+    );
+  }
 
   return (
     <Pressable
@@ -211,6 +229,13 @@ const styles = StyleSheet.create({
   caption: {
     color: 'rgba(255,255,255,0.7)',
     fontSize: 12,
+  },
+  emptyContainer: {
+    justifyContent: 'center',
+  },
+  emptyTitle: {
+    flex: 0,
+    textAlign: 'center',
   },
 });
 

--- a/MedTrackApp/src/screens/MedCalendarScreen/EmptyDayState.tsx
+++ b/MedTrackApp/src/screens/MedCalendarScreen/EmptyDayState.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
+
+export type Props = {
+  onAddReminder: () => void;
+  selectedDate: Date;
+  style?: import('react-native').ViewStyle;
+};
+
+const EmptyDayState: React.FC<Props> = ({ onAddReminder, style }) => {
+  return (
+    <View style={[styles.container, style]}>
+      <Image
+        source={require('../../../assets/Happy_Pill_Dive.png')}
+        style={styles.image}
+        accessibilityLabel="Пустой список напоминаний"
+      />
+      <Text style={styles.title}>На этот день нет напоминаний</Text>
+      <Text style={styles.subtitle}>Запланируйте приём, чтобы ничего не забыть</Text>
+      <TouchableOpacity
+        onPress={onAddReminder}
+        style={styles.button}
+        accessibilityRole="button"
+        accessibilityLabel="Добавить напоминание на сегодня"
+      >
+        <Text style={styles.buttonText}>Добавить напоминание на сегодня</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+  },
+  image: {
+    width: 180,
+    height: 180,
+    resizeMode: 'contain',
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#fff',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#AAA',
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  button: {
+    backgroundColor: '#007AFF',
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderRadius: 5,
+    width: '100%',
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});
+
+export default EmptyDayState;

--- a/MedTrackApp/src/screens/MedCalendarScreen/MedCalendarScreen.tsx
+++ b/MedTrackApp/src/screens/MedCalendarScreen/MedCalendarScreen.tsx
@@ -36,6 +36,7 @@ import { getWeekDates } from './utils';
 import { statusColors, typeIcons } from './constants';
 import { useCountdown, useCourses } from '../../hooks';
 import MedicationDayStatsButton from '../../components/MedicationDayStatsButton';
+import EmptyDayState from './EmptyDayState';
 
 const applyStatusRules = (items: Reminder[]): Reminder[] => {
   const now = Date.now();
@@ -363,14 +364,15 @@ const MedCalendarScreen: React.FC = () => {
             keyExtractor={(item) => item.id}
             renderItem={({ item }) => <ReminderCard item={item} />}
             ListEmptyComponent={() => (
-              <View style={styles.emptyListContainer}>
-                <Icon name="pill-off" size={60} color="#444" />
-                <Text style={styles.emptyListText}>Нет напоминаний на этот день</Text>
-                <Text style={styles.emptyListSubText}>Нажмите на + чтобы добавить</Text>
-              </View>
+              <EmptyDayState
+                selectedDate={new Date(selectedDate)}
+                onAddReminder={() =>
+                  navigation.navigate('ReminderAdd', { selectedDate, mainKey: route.key })
+                }
+              />
             )}
             // убираем лишний нижний отступ (TabNavigator сам занимает низ)
-            contentContainerStyle={{ paddingBottom: 0 }}
+            contentContainerStyle={{ flexGrow: 1, paddingBottom: 0 }}
           />
 
           {/* Speed Dial FAB */}

--- a/MedTrackApp/src/screens/MedCalendarScreen/styles.ts
+++ b/MedTrackApp/src/screens/MedCalendarScreen/styles.ts
@@ -188,21 +188,4 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginLeft: 8,
   },
-  emptyListContainer: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 50,
-  },
-  emptyListText: {
-    color: '#AAA',
-    fontSize: 18,
-    marginTop: 20,
-    fontWeight: 'bold',
-  },
-  emptyListSubText: {
-    color: '#666',
-    fontSize: 14,
-    marginTop: 10,
-  },
 });


### PR DESCRIPTION
## Summary
- show friendly illustration and CTA button when a day has no reminders
- render neutral daily stats text if nothing scheduled
- add reusable `EmptyDayState` component

## Testing
- `npm test`
- `npm run lint` *(fails: 7 errors, 187 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cc212030832f9132cc27b42d3ee6