### PR TITLE
Clean up redundant comments

### DIFF
--- a/MedTrackApp/src/components/AddFoodModal.tsx
+++ b/MedTrackApp/src/components/AddFoodModal.tsx
@@ -69,7 +69,6 @@ const AddFoodModal: React.FC<AddFoodModalProps> = ({
   const [query, setQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchItem[]>([]);
 
-  // FIX: хранить выбранное как объединение, а не только CatalogItem
   const [selectedCatalog, setSelectedCatalog] = useState<CatalogItem | UserCatalogItem | null>(null);
   const [selectedSource, setSelectedSource] = useState<'catalog' | 'user' | null>(null);
 
@@ -128,7 +127,6 @@ const AddFoodModal: React.FC<AddFoodModalProps> = ({
     type: 'catalog' | 'user' | 'favorite',
   ) => (type === 'favorite' ? favKey(item as FavoriteItem) : (item as CatalogItem | UserCatalogItem).id);
 
-  // FIX: поднял вычисление allSearchItems ВЫШЕ всех useEffect, которые на него ссылаются
   const allSearchItems = useMemo<SearchItem[]>(() => {
     const map = new Map<string, SearchItem>();
     localCatalog.forEach(it => map.set(itemKey(it, 'catalog'), { type: 'catalog', item: it }));
@@ -141,7 +139,6 @@ const AddFoodModal: React.FC<AddFoodModalProps> = ({
     );
   }, [userCatalog, favorites]);
 
-  // FIX: этот эффект теперь после объявления allSearchItems
   useEffect(() => {
     if (!ingredientPickerVisible) return;
     const q = ingredientSearch.trim().toLowerCase();
@@ -603,7 +600,6 @@ const AddFoodModal: React.FC<AddFoodModalProps> = ({
                   : '',
               );
             } else {
-              // FIX: сохраняем как объединённый тип + правильный источник
               setSelectedCatalog(data as CatalogItem | UserCatalogItem);
               setSelectedSource(item.type === 'catalog' ? 'catalog' : 'user');
             }
@@ -754,7 +750,6 @@ const AddFoodModal: React.FC<AddFoodModalProps> = ({
     const handleToggle = () => {
       if (selectedCatalog) {
         const type = selectedSource === 'user' ? 'user' : 'catalog';
-        // FIX: создаём корректный SearchItem по источнику
         if (type === 'catalog') {
           toggleFavorite({ type: 'catalog', item: selectedCatalog as CatalogItem });
         } else {

--- a/MedTrackApp/src/components/WaterTracker.tsx
+++ b/MedTrackApp/src/components/WaterTracker.tsx
@@ -1,4 +1,3 @@
-// components/WaterTracker.tsx
 import React, { useMemo, useRef, useEffect, useState } from 'react';
 import {
   View,

--- a/MedTrackApp/src/health/ios.healthkit.ts
+++ b/MedTrackApp/src/health/ios.healthkit.ts
@@ -1,4 +1,3 @@
-// src/health/ios.healthkit.ts
 import { Platform } from 'react-native';
 import type {
   DateRange, EnergySample, HealthSource, HRSample, StepSample, WeightSample, Workout, Scope, Unsubscribe, DataType,

--- a/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
+++ b/MedTrackApp/src/screens/AccountScreen/AccountScreen.tsx
@@ -256,9 +256,7 @@ const AccountScreen: React.FC = () => {
           }));
           setPhoneInput(formatPhone(parsed.phone || ''));
         }
-      } catch {
-        // ignore
-      }
+      } catch {}
     };
     load();
   }, []);
@@ -316,9 +314,7 @@ const AccountScreen: React.FC = () => {
             STORAGE_KEY,
             JSON.stringify({ ...parsed, avatarUri: uri }),
           );
-        } catch {
-          // ignore
-        }
+        } catch {}
       }
     });
   };
@@ -495,7 +491,6 @@ const AccountScreen: React.FC = () => {
                 <Text style={styles.sectionTitle}>Соцсети</Text>
                 <Text style={styles.label}>ВКонтакте</Text>
                 <View style={styles.rowInput}>
-                  {/* <VKIcon width={20} height={20} style={styles.svgIcon} fill="#fff" /> */}
                   <View style={styles.socialField}>
                     <Text style={styles.prefixText}>vk.com/</Text>
                     <TextInput
@@ -511,12 +506,6 @@ const AccountScreen: React.FC = () => {
                 </View>
                 <Text style={styles.label}>Instagram</Text>
                 <View style={styles.rowInput}>
-                  {/* <InstagramIcon
-                    width={20}
-                    height={20}
-                    style={styles.svgIcon}
-                    fill="#fff"
-                  /> */}
                   <View style={styles.socialField}>
                     <Text style={styles.prefixText}>instagram.com/</Text>
                     <TextInput
@@ -532,12 +521,6 @@ const AccountScreen: React.FC = () => {
                 </View>
                 <Text style={styles.label}>Telegram</Text>
                 <View style={styles.rowInput}>
-                  {/* <TelegramIcon
-                    width={20}
-                    height={20}
-                    style={styles.svgIcon}
-                    fill="#fff"
-                  /> */}
                   <View style={styles.socialField}>
                     <Text style={styles.prefixText}>t.me/</Text>
                     <TextInput

--- a/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
+++ b/MedTrackApp/src/screens/DietScreen/DietScreen.tsx
@@ -1,4 +1,3 @@
-// screens/diet/DietScreen.tsx
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import WaterTracker from '../../components/WaterTracker';
 import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react';

--- a/MedTrackApp/src/screens/MainScreen/MainScreen.tsx
+++ b/MedTrackApp/src/screens/MainScreen/MainScreen.tsx
@@ -1,4 +1,3 @@
-// screens/main/MainScreen.tsx
 import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import {
   View,

--- a/MedTrackApp/src/screens/MainScreen/styles.ts
+++ b/MedTrackApp/src/screens/MainScreen/styles.ts
@@ -1,4 +1,3 @@
-// screens/main/styles.ts
 import { StyleSheet } from 'react-native';
 
 const YELLOW = '#FFC107';

--- a/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
+++ b/MedTrackApp/src/screens/NutritionStats/NutritionStatsScreen.tsx
@@ -1,4 +1,3 @@
-// screens/nutrition/NutritionStatsScreen.tsx
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { View, Text, ScrollView, AccessibilityInfo, Animated, Easing } from 'react-native';
 import { RouteProp } from '@react-navigation/native';

--- a/MedTrackApp/src/screens/Profile/Profile.tsx
+++ b/MedTrackApp/src/screens/Profile/Profile.tsx
@@ -31,7 +31,7 @@ const Profile: React.FC = () => {
     adherence_percentage: 0,
   });
 
-  const screenWidth = Dimensions.get('window').width - 40; // Account for padding
+  const screenWidth = Dimensions.get('window').width - 40;
 
   useEffect(() => {
     navigation.setOptions({ headerTitle: 'Profile' });
@@ -51,7 +51,6 @@ const Profile: React.FC = () => {
     };
     loadUser();
   }, []);
-
 
   const loadStats = async () => {
     try {
@@ -113,16 +112,11 @@ const Profile: React.FC = () => {
     );
   };
 
-
-
-  // Navigate to medications management
   const navigateToMedications = () => {
-    // Switch to the Medications tab instead of pushing a new screen on top
     const parentNavigator = navigation.getParent();
     parentNavigator?.navigate('Препараты');
   };
 
-  // Data for bar chart
   const barData = {
     labels: ['Принято', 'Пропущено'],
     datasets: [
@@ -133,7 +127,6 @@ const Profile: React.FC = () => {
     ],
   };
 
-  // Chart configuration
   const chartConfig = {
     backgroundGradientFrom: '#1E1E1E',
     backgroundGradientTo: '#1E1E1E',
@@ -150,7 +143,6 @@ const Profile: React.FC = () => {
     },
   };
 
-  // Get adherence color based on percentage
   const getAdherenceColor = (percentage: number): string => {
     if (percentage >= 80) return '#4CAF50'; // Good - Green
     if (percentage >= 60) return '#FFC107'; // Okay - Yellow
@@ -164,24 +156,17 @@ const Profile: React.FC = () => {
       <StatusBar barStyle="light-content" />
       <ScrollView contentContainerStyle={styles.scrollContainer}>
 
-
-
-
-
-
-        {/* Medication Adherence Section */}
         <View style={styles.adherenceSection}>
           <Text style={styles.sectionTitle}>Статистика</Text>
-          
-          {/* Adherence Rate - Enhanced Circular Progress */}
+
           <View style={styles.chartContainer}>
             <Text style={styles.chartTitle}>Процент соблюдения</Text>
             <View style={styles.centeredChart}>
-              <AdherenceDisplay 
-                percentage={user.adherence_percentage} 
-                color={adherenceColor} 
+              <AdherenceDisplay
+                percentage={user.adherence_percentage}
+                color={adherenceColor}
               />
-              
+
               <View style={styles.adherenceLegend}>
                 <View style={styles.legendItem}>
                   <View style={[styles.legendDot, { backgroundColor: '#4CAF50' }]} />
@@ -195,7 +180,6 @@ const Profile: React.FC = () => {
             </View>
           </View>
 
-          {/* Medications Summary - Bar Chart */}
           <View style={styles.chartContainer}>
             <Text style={styles.chartTitle}>Общая информация</Text>
             <BarChart
@@ -217,8 +201,6 @@ const Profile: React.FC = () => {
               showValuesOnTopOfBars
             />
           </View>
-
-          {/* Stats Summary */}
           <View style={styles.statsGrid}>
             <View style={styles.statCard}>
               <Text style={styles.statValue}>{user.total_taken}</Text>

--- a/MedTrackApp/src/screens/Profile/styles.ts
+++ b/MedTrackApp/src/screens/Profile/styles.ts
@@ -62,7 +62,6 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     fontSize: 16,
   },
-  // Update button styles
   updateButton: {
     flexDirection: 'row',
     backgroundColor: '#007AFF',
@@ -81,7 +80,6 @@ export const styles = StyleSheet.create({
     backgroundColor: '#3A5D7E',
     opacity: 0.7,
   },
-  // Enhanced adherence section styles
   adherenceSection: {
     backgroundColor: '#1E1E1E',
     borderRadius: 10,
@@ -104,7 +102,6 @@ export const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   
-  // New adherence display styles
   adherenceContainer: {
     position: 'relative',
     alignItems: 'center',
@@ -180,7 +177,6 @@ export const styles = StyleSheet.create({
     fontSize: 14,
   },
   
-  // Keep the existing styles you need
   statsGrid: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -200,7 +196,6 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: 5,
   },
-  // Update statLabel styles to make Пропущено fit
   statLabel: {
     color: '#888',
     fontSize: 12,

--- a/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
+++ b/MedTrackApp/src/screens/ReminderAdd/ReminderAdd.tsx
@@ -81,7 +81,6 @@ const ReminderAdd: React.FC = () => {
     return date;
   });
 
-  // Ensure single-day course when repeating once
   useEffect(() => {
     if (repeat === 'once') {
       setEndDate(startDate);
@@ -400,46 +399,45 @@ const ReminderAdd: React.FC = () => {
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
         <ScrollView showsVerticalScrollIndicator={false}>
-        <View style={styles.header}>
-          {/* Сделать чтобы было похоже на листание с правой станицы на левую, а не наоборот */}
-          <TouchableOpacity onPress={() => navigation.goBack()}>
-            <Icon name="arrow-left" size={28} color="#007AFF" />
+          <View style={styles.header}>
+            <TouchableOpacity onPress={() => navigation.goBack()}>
+              <Icon name="arrow-left" size={28} color="#007AFF" />
+            </TouchableOpacity>
+            <Text style={styles.headerTitle}>Добавить напоминание</Text>
+          </View>
+          <Text style={styles.dateInfo}>
+            {startDate === endDate
+              ? `Дата: ${formatDateRu(startDate)}`
+              : `Курс: ${formatDateRu(startDate)} - ${formatDateRu(endDate)}`}
+          </Text>
+
+          <Text style={styles.label}>Название</Text>
+          <TextInput
+            style={styles.input}
+            value={name}
+            onChangeText={setName}
+            maxLength={35}
+            placeholder="Название лекарства"
+            placeholderTextColor="#666"
+          />
+          <TouchableOpacity onPress={() => setSelectVisible(true)} style={styles.selectButton}>
+            <Icon name="format-list-bulleted" size={20} color="#007AFF" />
+            <Text style={styles.selectButtonText}>Выбрать из добавленных</Text>
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>Добавить напоминание</Text>
-        </View>
-        <Text style={styles.dateInfo}>
-          {startDate === endDate
-            ? `Дата: ${formatDateRu(startDate)}`
-            : `Курс: ${formatDateRu(startDate)} - ${formatDateRu(endDate)}`}
-        </Text>
 
-        <Text style={styles.label}>Название</Text>
-        <TextInput
-          style={styles.input}
-          value={name}
-          onChangeText={setName}
-          maxLength={35}
-          placeholder="Название лекарства"
-          placeholderTextColor="#666"
-        />
-        <TouchableOpacity onPress={() => setSelectVisible(true)} style={styles.selectButton}>
-          <Icon name="format-list-bulleted" size={20} color="#007AFF" />
-          <Text style={styles.selectButtonText}>Выбрать из добавленных</Text>
-        </TouchableOpacity>
+          <Text style={styles.label}>Дозировка</Text>
+          <TextInput
+            style={styles.input}
+            value={dosage}
+            keyboardType="default"
+            maxLength={35}
+            onChangeText={setDosage}
+            placeholder="Например: 1"
+            placeholderTextColor="#666"
+          />
 
-        <Text style={styles.label}>Дозировка</Text>
-        <TextInput
-          style={styles.input}
-          value={dosage}
-          keyboardType="default"
-          maxLength={35}
-          onChangeText={setDosage}
-          placeholder="Например: 1"
-          placeholderTextColor="#666"
-        />
-
-        <Text style={styles.label}>Тип</Text>
-        <View style={styles.typeContainer}>
+          <Text style={styles.label}>Тип</Text>
+          <View style={styles.typeContainer}>
           {typeOptions.map((option) => (
             <TouchableOpacity
               key={option.value}

--- a/MedTrackApp/src/screens/ReminderAdd/styles.ts
+++ b/MedTrackApp/src/screens/ReminderAdd/styles.ts
@@ -79,7 +79,6 @@ export const styles = StyleSheet.create({
     marginLeft: 10,
     fontSize: 16,
   },
-  // Styles for multiple times
   timesList: {
     marginBottom: 10,
   },
@@ -167,7 +166,6 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     fontSize: 16,
   },
-  // Modal styles
   modalOverlay: {
     flex: 1,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',

--- a/MedTrackApp/src/screens/ReminderEdit/ReminderEdit.tsx
+++ b/MedTrackApp/src/screens/ReminderEdit/ReminderEdit.tsx
@@ -64,7 +64,6 @@ const ReminderEdit: React.FC = () => {
 
   const saveReminder = async () => {
     try {
-      // Create updated reminder
       const updatedReminder: Reminder = {
         ...reminder,
         name,
@@ -72,23 +71,18 @@ const ReminderEdit: React.FC = () => {
         time,
       };
 
-      // Retrieve existing reminders from AsyncStorage
       const storedRemindersJson = await AsyncStorage.getItem('reminders');
-      
+
       if (storedRemindersJson) {
-        // Parse stored reminders
         const storedReminders: Reminder[] = JSON.parse(storedRemindersJson);
 
-        // Find and replace the updated reminder
-        const updatedReminders = storedReminders.map(r => 
+        const updatedReminders = storedReminders.map(r =>
           r.id === reminder.id ? updatedReminder : r
         );
 
-        // Save updated reminders back to AsyncStorage
         await AsyncStorage.setItem('reminders', JSON.stringify(updatedReminders));
       }
 
-      // Navigate back to Main screen with updated reminder
       const key = mainKey || navigation.getState().routes[0]?.key;
       navigation.goBack();
       // @ts-ignore

--- a/MedTrackApp/src/screens/ReminderEdit/styles.ts
+++ b/MedTrackApp/src/screens/ReminderEdit/styles.ts
@@ -51,7 +51,6 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     fontSize: 16,
   },
-  // Modal styles
   modalOverlay: {
     flex: 1,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',


### PR DESCRIPTION
## Summary
- remove stale FIX notes and header comments across the health utilities and shared components
- strip redundant explanatory or commented-out JSX from profile and account flows while keeping functionality intact
- tidy reminder-related screens by excising noise comments and preserving formatting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbcd9ef3d8832fb9a768c160f94631